### PR TITLE
feat: retry audit data resolution for recent users

### DIFF
--- a/internal/controller/fraudevaluation_controller.go
+++ b/internal/controller/fraudevaluation_controller.go
@@ -19,6 +19,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
+	iamv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
+
 	fraudv1alpha1 "go.miloapis.com/fraud/api/v1alpha1"
 	"go.miloapis.com/fraud/internal/datasource"
 	"go.miloapis.com/fraud/internal/provider"
@@ -28,6 +30,14 @@ const (
 	defaultMaxHistoryEntries = 50
 
 	actionNone = "NONE"
+
+	// recentUserThreshold is the maximum age of a user for which the
+	// reconciler will retry resolution of incomplete audit data.
+	recentUserThreshold = 2 * time.Minute
+
+	// auditDataRetryDelay is the requeue interval when waiting for
+	// audit log data to become available for a recent user.
+	auditDataRetryDelay = 5 * time.Second
 )
 
 // actionPriority maps decision strings to a numeric priority for comparison.
@@ -77,9 +87,11 @@ func (r *FraudEvaluationReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	// 3. Set phase to Running and update status.
-	eval.Status.Phase = "Running"
-	if err := r.Status().Update(ctx, &eval); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to set phase to Running: %w", err)
+	if eval.Status.Phase != "Running" {
+		eval.Status.Phase = "Running"
+		if err := r.Status().Update(ctx, &eval); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to set phase to Running: %w", err)
+		}
 	}
 
 	// 4. Fetch the referenced FraudPolicy.
@@ -103,11 +115,24 @@ func (r *FraudEvaluationReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	var input provider.Input
 	if r.Resolver != nil {
 		resolved, err := r.Resolver.Resolve(ctx, eval.Spec.UserRef.Name)
+		input = resolved
+
 		if err != nil {
+			// Audit data is incomplete. For recent users, requeue to allow
+			// the data to become available before calling providers.
+			var user iamv1alpha1.User
+			if userErr := r.Get(ctx, types.NamespacedName{Name: eval.Spec.UserRef.Name}, &user); userErr == nil {
+				if time.Since(user.CreationTimestamp.Time) < recentUserThreshold {
+					log.Info("audit data incomplete for recent user, will retry",
+						"user", eval.Spec.UserRef.Name,
+						"userAge", time.Since(user.CreationTimestamp.Time).Round(time.Second))
+
+					return ctrl.Result{RequeueAfter: auditDataRetryDelay}, nil
+				}
+			}
+
 			log.V(1).Info("data source resolution had errors, continuing with partial input", "error", err)
 		}
-
-		input = resolved
 	}
 
 	// 6. Execute stages in order.

--- a/internal/controller/fraudevaluation_controller.go
+++ b/internal/controller/fraudevaluation_controller.go
@@ -249,7 +249,7 @@ func (r *FraudEvaluationReconciler) executeStages(
 		)
 
 		for _, sp := range stage.Providers {
-			pr, score, err := r.evaluateProvider(ctx, eval, sp, input)
+			pr, score, err := r.evaluateProvider(ctx, sp, input)
 			if err != nil {
 				providerResults = append(providerResults, pr)
 				sr.ProviderResults = providerResults
@@ -312,7 +312,6 @@ func (r *FraudEvaluationReconciler) executeStages(
 // error string but the returned error is nil.
 func (r *FraudEvaluationReconciler) evaluateProvider(
 	ctx context.Context,
-	eval *fraudv1alpha1.FraudEvaluation,
 	sp fraudv1alpha1.StageProvider,
 	input provider.Input,
 ) (fraudv1alpha1.ProviderResult, float64, error) {

--- a/internal/controller/fraudevaluation_controller.go
+++ b/internal/controller/fraudevaluation_controller.go
@@ -112,166 +112,23 @@ func (r *FraudEvaluationReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	// 5. Resolve provider input from platform data sources.
-	var input provider.Input
-	if r.Resolver != nil {
-		resolved, err := r.Resolver.Resolve(ctx, eval.Spec.UserRef.Name)
-		input = resolved
-
-		if err != nil {
-			// Audit data is incomplete. For recent users, requeue to allow
-			// the data to become available before calling providers.
-			var user iamv1alpha1.User
-			if userErr := r.Get(ctx, types.NamespacedName{Name: eval.Spec.UserRef.Name}, &user); userErr == nil {
-				if time.Since(user.CreationTimestamp.Time) < recentUserThreshold {
-					log.Info("audit data incomplete for recent user, will retry",
-						"user", eval.Spec.UserRef.Name,
-						"userAge", time.Since(user.CreationTimestamp.Time).Round(time.Second))
-
-					return ctrl.Result{RequeueAfter: auditDataRetryDelay}, nil
-				}
-			}
-
-			log.V(1).Info("data source resolution had errors, continuing with partial input", "error", err)
-		}
+	input, retry := r.resolveInput(ctx, &eval)
+	if retry != nil {
+		return *retry, nil
 	}
 
-	// 6. Execute stages in order.
-	stageResults := make([]fraudv1alpha1.StageResult, 0, len(policy.Spec.Stages))
+	// 6. Execute stages and evaluate thresholds.
+	stageResults, compositeScore, decision, err := r.executeStages(ctx, &eval, policy.Spec.Stages, input)
+	eval.Status.StageResults = stageResults
 
-	var (
-		shortCircuitActive bool
-		allMatchedActions  []string
-		compositeScore     float64
-	)
-
-	for _, stage := range policy.Spec.Stages {
-		sr := fraudv1alpha1.StageResult{
-			Name: stage.Name,
-		}
-
-		// Check short-circuit: skip non-required stages when short-circuit is active.
-		if shortCircuitActive && !stage.Required {
-			sr.Skipped = true
-			stageResults = append(stageResults, sr)
-			log.V(1).Info("skipping stage due to short-circuit", "stage", stage.Name)
-
-			continue
-		}
-
-		var (
-			maxStageScore    float64
-			providerResults  []fraudv1alpha1.ProviderResult
-			providerDegraded bool
-		)
-
-		for _, sp := range stage.Providers {
-			// Look up the FraudProvider CR.
-			var fp fraudv1alpha1.FraudProvider
-			fpKey := types.NamespacedName{Name: sp.ProviderRef.Name}
-
-			if err := r.Get(ctx, fpKey, &fp); err != nil {
-				return r.setErrorPhase(ctx, &eval, fmt.Sprintf("failed to fetch FraudProvider %q: %v", sp.ProviderRef.Name, err))
-			}
-
-			// Get the provider implementation from the registry by CR name.
-			impl, ok := r.Registry.Get(sp.ProviderRef.Name)
-			if !ok {
-				return r.setErrorPhase(ctx, &eval, fmt.Sprintf("provider %q is not yet initialized (Available condition may be false)", sp.ProviderRef.Name))
-			}
-
-			// Call the provider.
-			start := time.Now()
-			result := impl.Evaluate(ctx, input)
-			duration := time.Since(start)
-
-			pr := fraudv1alpha1.ProviderResult{
-				Provider:    sp.ProviderRef.Name,
-				Score:       strconv.FormatFloat(result.Score, 'f', 2, 64),
-				RawResponse: result.RawResponse,
-				Duration:    duration.Round(time.Millisecond).String(),
-			}
-
-			if result.Error != nil {
-				failurePolicy := fp.Spec.FailurePolicy
-				if failurePolicy == "" {
-					failurePolicy = "FailOpen"
-				}
-
-				pr.Error = result.Error.Error()
-				pr.FailurePolicyApplied = failurePolicy
-
-				if failurePolicy == "FailClosed" {
-					// FailClosed: abort the entire evaluation with an error.
-					providerResults = append(providerResults, pr)
-					sr.ProviderResults = providerResults
-					stageResults = append(stageResults, sr)
-					eval.Status.StageResults = stageResults
-
-					return r.setErrorPhase(ctx, &eval,
-						fmt.Sprintf("provider %q failed with FailClosed policy: %v", sp.ProviderRef.Name, result.Error))
-				}
-
-				// FailOpen: record the error, continue with score = 0.
-				pr.Score = "0.00"
-				providerDegraded = true
-
-				log.Info("provider error with FailOpen policy, continuing", "provider", sp.ProviderRef.Name, "error", result.Error)
-			}
-
-			providerResults = append(providerResults, pr)
-
-			if result.Score > maxStageScore {
-				maxStageScore = result.Score
-			}
-		}
-
-		sr.ProviderResults = providerResults
-		stageResults = append(stageResults, sr)
-
-		// Track composite score as the max across all non-skipped stages.
-		if maxStageScore > compositeScore {
-			compositeScore = maxStageScore
-		}
-
-		// Check thresholds: find the highest matching threshold.
-		matchedAction := r.evaluateThresholds(stage.Thresholds, int(maxStageScore))
-		if matchedAction != "" {
-			allMatchedActions = append(allMatchedActions, matchedAction)
-
-			// Record event for threshold crossing.
-			if r.Recorder != nil {
-				r.Recorder.Eventf(&eval, nil, corev1.EventTypeWarning, "ThresholdCrossed", "EvaluateThreshold",
-					"Stage %q: score %.2f triggered %s threshold", stage.Name, maxStageScore, matchedAction)
-			}
-		}
-
-		// Check short-circuit configuration.
-		if stage.ShortCircuit != nil && int(maxStageScore) < stage.ShortCircuit.SkipWhenBelow {
-			shortCircuitActive = true
-			log.V(1).Info("short-circuit activated", "stage", stage.Name, "score", maxStageScore, "skipWhenBelow", stage.ShortCircuit.SkipWhenBelow)
-		}
-
-		// Set degraded condition if any provider had an error.
-		if providerDegraded {
-			meta.SetStatusCondition(&eval.Status.Conditions, metav1.Condition{
-				Type:               "Degraded",
-				Status:             metav1.ConditionTrue,
-				Reason:             "ProviderError",
-				Message:            fmt.Sprintf("One or more providers in stage %q returned errors", stage.Name),
-				ObservedGeneration: eval.Generation,
-			})
-		}
+	if err != nil {
+		return r.setErrorPhase(ctx, &eval, err.Error())
 	}
 
-	// 6. Composite score is already computed as max across non-skipped stages.
-
-	// 7. Determine decision: highest severity action from all matched thresholds.
-	decision := r.highestAction(allMatchedActions)
-
-	// 8. Determine enforcement action based on policy mode.
+	// 7. Determine enforcement action based on policy mode.
 	enforcementAction := r.determineEnforcement(policy.Spec.Enforcement.Mode, decision)
 
-	// 9. Add to history (prepend, trim to maxEntries).
+	// 8. Add to history (prepend, trim to maxEntries).
 	now := metav1.Now()
 
 	compositeScoreStr := strconv.FormatFloat(compositeScore, 'f', 2, 64)
@@ -288,7 +145,7 @@ func (r *FraudEvaluationReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		eval.Status.History = eval.Status.History[:maxEntries]
 	}
 
-	// 10. Set phase to Completed and update all status fields.
+	// 9. Set phase to Completed and update all status fields.
 	eval.Status.Phase = "Completed"
 	eval.Status.CompositeScore = compositeScoreStr
 	eval.Status.Decision = decision
@@ -315,6 +172,199 @@ func (r *FraudEvaluationReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		"stages", len(stageResults))
 
 	return ctrl.Result{}, nil
+}
+
+// resolveInput resolves the provider input from platform data sources. If audit
+// data is missing and the user was created recently, it returns a requeue result
+// so the reconciler can retry. Otherwise it returns the (possibly partial) input.
+func (r *FraudEvaluationReconciler) resolveInput(
+	ctx context.Context,
+	eval *fraudv1alpha1.FraudEvaluation,
+) (provider.Input, *ctrl.Result) {
+	log := logf.FromContext(ctx)
+
+	if r.Resolver == nil {
+		return provider.Input{}, nil
+	}
+
+	input, err := r.Resolver.Resolve(ctx, eval.Spec.UserRef.Name)
+	if err == nil {
+		return input, nil
+	}
+
+	// Audit data is incomplete. For recent users, requeue to allow the
+	// data to become available before calling providers.
+	var user iamv1alpha1.User
+	if userErr := r.Get(ctx, types.NamespacedName{Name: eval.Spec.UserRef.Name}, &user); userErr == nil {
+		if time.Since(user.CreationTimestamp.Time) < recentUserThreshold {
+			log.Info("audit data incomplete for recent user, will retry",
+				"user", eval.Spec.UserRef.Name,
+				"userAge", time.Since(user.CreationTimestamp.Time).Round(time.Second))
+
+			return input, &ctrl.Result{RequeueAfter: auditDataRetryDelay}
+		}
+	}
+
+	log.V(1).Info("data source resolution had errors, continuing with partial input", "error", err)
+
+	return input, nil
+}
+
+// executeStages runs all policy stages against the resolved input and returns
+// the stage results, composite score, and final decision.
+func (r *FraudEvaluationReconciler) executeStages(
+	ctx context.Context,
+	eval *fraudv1alpha1.FraudEvaluation,
+	stages []fraudv1alpha1.Stage,
+	input provider.Input,
+) ([]fraudv1alpha1.StageResult, float64, string, error) {
+	log := logf.FromContext(ctx)
+
+	stageResults := make([]fraudv1alpha1.StageResult, 0, len(stages))
+
+	var (
+		shortCircuitActive bool
+		allMatchedActions  []string
+		compositeScore     float64
+	)
+
+	for _, stage := range stages {
+		sr := fraudv1alpha1.StageResult{
+			Name: stage.Name,
+		}
+
+		// Check short-circuit: skip non-required stages when short-circuit is active.
+		if shortCircuitActive && !stage.Required {
+			sr.Skipped = true
+			stageResults = append(stageResults, sr)
+			log.V(1).Info("skipping stage due to short-circuit", "stage", stage.Name)
+
+			continue
+		}
+
+		var (
+			maxStageScore    float64
+			providerResults  []fraudv1alpha1.ProviderResult
+			providerDegraded bool
+		)
+
+		for _, sp := range stage.Providers {
+			pr, score, err := r.evaluateProvider(ctx, eval, sp, input)
+			if err != nil {
+				providerResults = append(providerResults, pr)
+				sr.ProviderResults = providerResults
+				stageResults = append(stageResults, sr)
+
+				return stageResults, compositeScore, "", err
+			}
+
+			providerResults = append(providerResults, pr)
+
+			if pr.Error != "" {
+				providerDegraded = true
+			}
+
+			if score > maxStageScore {
+				maxStageScore = score
+			}
+		}
+
+		sr.ProviderResults = providerResults
+		stageResults = append(stageResults, sr)
+
+		if maxStageScore > compositeScore {
+			compositeScore = maxStageScore
+		}
+
+		matchedAction := r.evaluateThresholds(stage.Thresholds, int(maxStageScore))
+		if matchedAction != "" {
+			allMatchedActions = append(allMatchedActions, matchedAction)
+
+			if r.Recorder != nil {
+				r.Recorder.Eventf(eval, nil, corev1.EventTypeWarning, "ThresholdCrossed", "EvaluateThreshold",
+					"Stage %q: score %.2f triggered %s threshold", stage.Name, maxStageScore, matchedAction)
+			}
+		}
+
+		if stage.ShortCircuit != nil && int(maxStageScore) < stage.ShortCircuit.SkipWhenBelow {
+			shortCircuitActive = true
+			log.V(1).Info("short-circuit activated", "stage", stage.Name, "score", maxStageScore, "skipWhenBelow", stage.ShortCircuit.SkipWhenBelow)
+		}
+
+		if providerDegraded {
+			meta.SetStatusCondition(&eval.Status.Conditions, metav1.Condition{
+				Type:               "Degraded",
+				Status:             metav1.ConditionTrue,
+				Reason:             "ProviderError",
+				Message:            fmt.Sprintf("One or more providers in stage %q returned errors", stage.Name),
+				ObservedGeneration: eval.Generation,
+			})
+		}
+	}
+
+	decision := r.highestAction(allMatchedActions)
+
+	return stageResults, compositeScore, decision, nil
+}
+
+// evaluateProvider calls a single provider and returns its result, score, and
+// any fatal error (FailClosed). For FailOpen errors the result includes the
+// error string but the returned error is nil.
+func (r *FraudEvaluationReconciler) evaluateProvider(
+	ctx context.Context,
+	eval *fraudv1alpha1.FraudEvaluation,
+	sp fraudv1alpha1.StageProvider,
+	input provider.Input,
+) (fraudv1alpha1.ProviderResult, float64, error) {
+	log := logf.FromContext(ctx)
+
+	var fp fraudv1alpha1.FraudProvider
+	if err := r.Get(ctx, types.NamespacedName{Name: sp.ProviderRef.Name}, &fp); err != nil {
+		return fraudv1alpha1.ProviderResult{},
+			0,
+			fmt.Errorf("failed to fetch FraudProvider %q: %w", sp.ProviderRef.Name, err)
+	}
+
+	impl, ok := r.Registry.Get(sp.ProviderRef.Name)
+	if !ok {
+		return fraudv1alpha1.ProviderResult{},
+			0,
+			fmt.Errorf("provider %q is not yet initialized (Available condition may be false)", sp.ProviderRef.Name)
+	}
+
+	start := time.Now()
+	result := impl.Evaluate(ctx, input)
+	duration := time.Since(start)
+
+	pr := fraudv1alpha1.ProviderResult{
+		Provider:    sp.ProviderRef.Name,
+		Score:       strconv.FormatFloat(result.Score, 'f', 2, 64),
+		RawResponse: result.RawResponse,
+		Duration:    duration.Round(time.Millisecond).String(),
+	}
+
+	if result.Error != nil {
+		failurePolicy := fp.Spec.FailurePolicy
+		if failurePolicy == "" {
+			failurePolicy = "FailOpen"
+		}
+
+		pr.Error = result.Error.Error()
+		pr.FailurePolicyApplied = failurePolicy
+
+		if failurePolicy == "FailClosed" {
+			return pr, 0, fmt.Errorf("provider %q failed with FailClosed policy: %w", sp.ProviderRef.Name, result.Error)
+		}
+
+		pr.Score = "0.00"
+
+		log.Info("provider error with FailOpen policy, continuing",
+			"provider", sp.ProviderRef.Name, "error", result.Error)
+
+		return pr, 0, nil
+	}
+
+	return pr, result.Score, nil
 }
 
 // evaluateThresholds finds the highest matching threshold action for the given score.

--- a/internal/controller/userfraudtrigger_controller.go
+++ b/internal/controller/userfraudtrigger_controller.go
@@ -4,7 +4,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,18 +17,6 @@ import (
 	iamv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
 
 	fraudv1alpha1 "go.miloapis.com/fraud/api/v1alpha1"
-)
-
-const (
-	// recentUserThreshold is the age threshold below which a user is
-	// considered recently created. For recent users the controller adds a
-	// short delay before creating the evaluation so that audit log data has
-	// time to propagate.
-	recentUserThreshold = 2 * time.Minute
-
-	// recentUserDelay is the requeue delay for recently created users to
-	// allow audit log data to become available before evaluation starts.
-	recentUserDelay = 30 * time.Second
 )
 
 // UserFraudTriggerReconciler watches User resources and automatically creates
@@ -84,16 +71,7 @@ func (r *UserFraudTriggerReconciler) Reconcile(
 		return ctrl.Result{}, nil
 	}
 
-	// 4. For recently created users, delay to allow audit log data to
-	//    propagate before the evaluation pipeline runs.
-	if userAge := time.Since(user.CreationTimestamp.Time); userAge < recentUserThreshold {
-		log.V(1).Info("user is recent, delaying evaluation creation",
-			"user", user.Name, "age", userAge.Round(time.Second))
-
-		return ctrl.Result{RequeueAfter: recentUserDelay}, nil
-	}
-
-	// 5. Create the FraudEvaluation.
+	// 4. Create the FraudEvaluation.
 	eval := &fraudv1alpha1.FraudEvaluation{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "eval-",

--- a/internal/datasource/resolver.go
+++ b/internal/datasource/resolver.go
@@ -45,8 +45,10 @@ func (r *Resolver) Resolve(ctx context.Context, userName string) (provider.Input
 	}
 
 	// Fetch the most recent audit log entry for the user.
+	var auditErr error
 	if err := r.resolveAuditLog(ctx, userName, &input); err != nil {
 		log.Info("failed to resolve audit log data, continuing with empty audit fields", "user", userName, "error", err)
+		auditErr = err
 	}
 
 	log.Info("resolved provider input",
@@ -57,7 +59,7 @@ func (r *Resolver) Resolve(ctx context.Context, userName string) (provider.Input
 		"userAgent", input.UserAgent,
 	)
 
-	return input, nil
+	return input, auditErr
 }
 
 // resolveUser fetches the User CR and populates email and name fields.


### PR DESCRIPTION
## Summary
- Move audit data retry logic from trigger reconciler to evaluation reconciler — the trigger now creates the FraudEvaluation immediately
- Evaluation reconciler requeues every 5s if audit data is missing and the user was created less than 2 minutes ago
- After the 2-minute window, proceeds with whatever data is available (graceful degradation)
- Resolver now returns audit resolution errors to the caller so it can decide whether to retry
