### PR TITLE
fix: skip PlatformAccessApproval creation if one already exists for user

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -71,6 +71,13 @@ rules:
   - iam.miloapis.com
   resources:
   - platformaccessapprovals
+  verbs:
+  - create
+  - get
+  - list
+- apiGroups:
+  - iam.miloapis.com
+  resources:
   - platformaccessrejections
   verbs:
   - create

--- a/internal/controller/fraudevaluation_controller.go
+++ b/internal/controller/fraudevaluation_controller.go
@@ -72,7 +72,7 @@ type FraudEvaluationReconciler struct {
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=iam.miloapis.com,resources=users,verbs=get
 // +kubebuilder:rbac:groups=iam.miloapis.com,resources=userdeactivations,verbs=get;create;update;patch
-// +kubebuilder:rbac:groups=iam.miloapis.com,resources=platformaccessapprovals,verbs=get;create
+// +kubebuilder:rbac:groups=iam.miloapis.com,resources=platformaccessapprovals,verbs=get;list;create
 // +kubebuilder:rbac:groups=iam.miloapis.com,resources=platformaccessrejections,verbs=get;create
 // +kubebuilder:rbac:groups=activity.miloapis.com,resources=auditlogqueries,verbs=create
 
@@ -491,6 +491,16 @@ func (r *FraudEvaluationReconciler) applyEnforcement(ctx context.Context, eval *
 		log.Info("PlatformAccessRejection ensured", "name", resourceName, "user", eval.Spec.UserRef.Name)
 
 	case fraudv1alpha1.DecisionAccepted:
+		var approvalList iamv1alpha1.PlatformAccessApprovalList
+		if err := r.List(ctx, &approvalList, client.MatchingFields{"spec.subjectRef.userRef.name": eval.Spec.UserRef.Name}); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to list PlatformAccessApprovals for user %q: %w", eval.Spec.UserRef.Name, err)
+		}
+
+		if len(approvalList.Items) > 0 {
+			log.Info("PlatformAccessApproval already exists for user, skipping creation", "user", eval.Spec.UserRef.Name)
+			break
+		}
+
 		approval := &iamv1alpha1.PlatformAccessApproval{
 			ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 			Spec: iamv1alpha1.PlatformAccessApprovalSpec{


### PR DESCRIPTION
## Summary

- Before creating a `PlatformAccessApproval` for an `ACCEPTED` decision, list existing approvals filtered by user name via the `spec.subjectRef.userRef.name` selectablefield
- If any approval already exists for the user, skip creation and proceed directly to marking enforcement as applied
- Adds `list` to the `platformaccessapprovals` RBAC verb set

## Test plan

- [ ] Verify that a `FraudEvaluation` with `ACCEPTED` decision where no prior approval exists still creates a `PlatformAccessApproval`
- [ ] Verify that a `FraudEvaluation` with `ACCEPTED` decision where an approval already exists for the user skips creation and sets `EnforcementApplied` condition
- [ ] Confirm no duplicate `PlatformAccessApproval` resources are created on re-reconcile