### PR TITLE
fix: drop MatchingFields lookup for PlatformAccessApproval idempotency

### DIFF
--- a/internal/controller/fraudevaluation_controller.go
+++ b/internal/controller/fraudevaluation_controller.go
@@ -491,16 +491,6 @@ func (r *FraudEvaluationReconciler) applyEnforcement(ctx context.Context, eval *
 		log.Info("PlatformAccessRejection ensured", "name", resourceName, "user", eval.Spec.UserRef.Name)
 
 	case fraudv1alpha1.DecisionAccepted:
-		var approvalList iamv1alpha1.PlatformAccessApprovalList
-		if err := r.List(ctx, &approvalList, client.MatchingFields{"spec.subjectRef.userRef.name": eval.Spec.UserRef.Name}); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to list PlatformAccessApprovals for user %q: %w", eval.Spec.UserRef.Name, err)
-		}
-
-		if len(approvalList.Items) > 0 {
-			log.Info("PlatformAccessApproval already exists for user, skipping creation", "user", eval.Spec.UserRef.Name)
-			break
-		}
-
 		approval := &iamv1alpha1.PlatformAccessApproval{
 			ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 			Spec: iamv1alpha1.PlatformAccessApprovalSpec{
@@ -517,7 +507,9 @@ func (r *FraudEvaluationReconciler) applyEnforcement(ctx context.Context, eval *
 		log.Info("PlatformAccessApproval ensured", "name", resourceName, "user", eval.Spec.UserRef.Name)
 
 	default:
-		return ctrl.Result{}, fmt.Errorf("unexpected decision %q on FraudEvaluation %q: cannot apply enforcement", eval.Status.Decision, eval.Name)
+		// Unknown or legacy decision value — log and skip enforcement rather than error-looping.
+		log.Info("skipping enforcement for unrecognised decision", "decision", eval.Status.Decision)
+		return r.setEnforcementAppliedCondition(ctx, eval, "SkippedUnknownDecision", fmt.Sprintf("Enforcement skipped: unrecognised decision %q", eval.Status.Decision))
 	}
 
 	return r.setEnforcementAppliedCondition(ctx, eval, "EnforcementApplied", fmt.Sprintf("Enforcement applied for decision %s", eval.Status.Decision))
@@ -544,19 +536,6 @@ func (r *FraudEvaluationReconciler) setEnforcementAppliedCondition(ctx context.C
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *FraudEvaluationReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &iamv1alpha1.PlatformAccessApproval{}, "spec.subjectRef.userRef.name", func(obj client.Object) []string {
-		paa, ok := obj.(*iamv1alpha1.PlatformAccessApproval)
-		if !ok {
-			return nil
-		}
-		if paa.Spec.SubjectRef.UserRef == nil {
-			return nil
-		}
-		return []string{paa.Spec.SubjectRef.UserRef.Name}
-	}); err != nil {
-		return fmt.Errorf("failed to set field index on PlatformAccessApproval: %w", err)
-	}
-
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&fraudv1alpha1.FraudEvaluation{}).
 		Named("fraudevaluation").

--- a/internal/controller/fraudevaluation_controller.go
+++ b/internal/controller/fraudevaluation_controller.go
@@ -544,6 +544,19 @@ func (r *FraudEvaluationReconciler) setEnforcementAppliedCondition(ctx context.C
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *FraudEvaluationReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &iamv1alpha1.PlatformAccessApproval{}, "spec.subjectRef.userRef.name", func(obj client.Object) []string {
+		paa, ok := obj.(*iamv1alpha1.PlatformAccessApproval)
+		if !ok {
+			return nil
+		}
+		if paa.Spec.SubjectRef.UserRef == nil {
+			return nil
+		}
+		return []string{paa.Spec.SubjectRef.UserRef.Name}
+	}); err != nil {
+		return fmt.Errorf("failed to set field index on PlatformAccessApproval: %w", err)
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&fraudv1alpha1.FraudEvaluation{}).
 		Named("fraudevaluation").


### PR DESCRIPTION
## Summary

- The `fraudevaluation` controller used `client.MatchingFields` to check if a `PlatformAccessApproval` already exists before creating one
- This requires a registered `IndexField` at manager startup — which was missing, causing two failures:
  1. **Staging**: every ACCEPTED evaluation error-looped with `Index with name field:spec.subjectRef.userRef.name does not exist`, leaving users stuck at `registrationApproval: Pending`
  2. **E2E tests**: registering the `IndexField` caused the controller to crash on startup in the Kind cluster (no `iam.miloapis.com` CRDs installed), putting the pod in CrashLoopBackOff
- Fix: replace the `List` + conditional `Create` with a direct `Create`, relying on `AlreadyExists` handling for idempotency. The PAA name is deterministic (`fraud-<eval-name>`), so this is equivalent with no index required
- Also fixes a separate staging error: evaluations with an unrecognised decision value (e.g. `"NONE"` from legacy data) were error-looping forever — they now log a warning and mark `EnforcementApplied` to stop retrying

## Test plan

- [ ] Deploy to staging and verify a new user signup flows through fraud evaluation → `PlatformAccessApproval` created → `registrationApproval` updated to `Approved`
- [ ] Verify existing stuck evaluations (`eval-r6qvz`, `eval-4qrnj`) self-heal on next reconcile after deploy
- [ ] Confirm no error logs for `Index with name field:spec.subjectRef.userRef.name does not exist`
- [ ] Confirm `eval-r7rwk` (decision `NONE`) stops error-looping and gets `EnforcementApplied` set
- [ ] E2E tests pass