### PR TITLE
feat: add spec.userRef.name field selector to FraudEvaluation

### DIFF
--- a/api/v1alpha1/fraudevaluation_types.go
+++ b/api/v1alpha1/fraudevaluation_types.go
@@ -167,6 +167,7 @@ type FraudEvaluationStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
+// +kubebuilder:selectablefield:JSONPath=`.spec.userRef.name`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`,description="Current evaluation phase"
 // +kubebuilder:printcolumn:name="Score",type=string,JSONPath=`.status.compositeScore`,description="Composite fraud score (0-100)"
 // +kubebuilder:printcolumn:name="Decision",type=string,JSONPath=`.status.decision`,description="Final fraud decision"

--- a/config/crd/bases/fraud.miloapis.com_fraudevaluations.yaml
+++ b/config/crd/bases/fraud.miloapis.com_fraudevaluations.yaml
@@ -286,6 +286,8 @@ spec:
         required:
         - spec
         type: object
+    selectableFields:
+    - jsonPath: .spec.userRef.name
     served: true
     storage: true
     subresources:

--- a/internal/controller/fraudevaluation_controller.go
+++ b/internal/controller/fraudevaluation_controller.go
@@ -536,6 +536,17 @@ func (r *FraudEvaluationReconciler) setEnforcementAppliedCondition(ctx context.C
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *FraudEvaluationReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(),
+		&fraudv1alpha1.FraudEvaluation{},
+		"spec.userRef.name",
+		func(obj client.Object) []string {
+			eval := obj.(*fraudv1alpha1.FraudEvaluation)
+			return []string{eval.Spec.UserRef.Name}
+		},
+	); err != nil {
+		return err
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&fraudv1alpha1.FraudEvaluation{}).
 		Named("fraudevaluation").


### PR DESCRIPTION
## Summary

- Adds `+kubebuilder:selectablefield` marker on `FraudEvaluation` for `spec.userRef.name`
- Registers a field indexer in `SetupWithManager` so the API server can filter evaluations by user
- Regenerates the CRD manifest with the `selectableFields` entry

## Test plan

- [ ] Apply updated CRD to cluster
- [ ] Verify `kubectl get fraudevaluations --field-selector spec.userRef.name=<user>` returns correct results
- [ ] Confirm staff portal fraud evaluation list query filters correctly by user