### PR TITLE
feat: add provider metrics, deploy kustomization, and alert configurations

### DIFF
--- a/config/prometheus/alerts.yaml
+++ b/config/prometheus/alerts.yaml
@@ -1,0 +1,59 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: fraud-alerts
+  namespace: system
+  labels:
+    app.kubernetes.io/name: fraud
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  groups:
+    - name: fraud-operator
+      rules:
+        - alert: FraudProviderHighErrorRate
+          expr: |
+            (
+              sum by (provider) (rate(fraud_provider_call_duration_seconds_count{result="failure"}[5m]))
+              /
+              sum by (provider) (rate(fraud_provider_call_duration_seconds_count[5m]))
+            ) > 0.1
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "High error rate for fraud provider {{ $labels.provider }}"
+            description: "{{ $value | humanizePercentage }} of calls to provider {{ $labels.provider }} are failing. With FailClosed policy, fraud evaluations will be blocked until this is resolved."
+
+        - alert: FraudProviderHighLatency
+          expr: |
+            histogram_quantile(0.99,
+              sum by (provider, le) (rate(fraud_provider_call_duration_seconds_bucket{result="success"}[5m]))
+            ) > 5
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "High latency for fraud provider {{ $labels.provider }}"
+            description: "P99 latency for provider {{ $labels.provider }} is {{ $value }}s, exceeding the 5s threshold."
+
+    - name: fraud-evaluations
+      rules:
+        - alert: FraudEvaluationsStuckInError
+          expr: |
+            count(fraud_evaluation_info{phase="Error"}) > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Fraud evaluations stuck in Error phase"
+            description: "{{ $value }} fraud evaluation(s) have been in the Error phase for 15+ minutes. This may indicate a persistent provider failure or misconfiguration."
+
+        - alert: FraudEvaluationDegraded
+          expr: |
+            fraud_evaluation_status_condition{condition="Degraded"} == 1
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Fraud evaluation {{ $labels.name }} is degraded"
+            description: "Fraud evaluation {{ $labels.name }} has been in a degraded state for 5+ minutes, indicating one or more providers returned errors during evaluation."

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - monitor.yaml
+- alerts.yaml
 
 # [PROMETHEUS-WITH-CERTS] The following patch configures the ServiceMonitor in ../prometheus
 # to securely reference certificates created and managed by cert-manager.

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - monitor.yaml
+- vmservicescrape.yaml
 - alerts.yaml
 
 # [PROMETHEUS-WITH-CERTS] The following patch configures the ServiceMonitor in ../prometheus

--- a/config/prometheus/vmservicescrape.yaml
+++ b/config/prometheus/vmservicescrape.yaml
@@ -1,0 +1,21 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: fraud
+    app.kubernetes.io/managed-by: kustomize
+  name: controller-manager-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - path: /metrics
+      port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: fraud

--- a/config/resourcemetrics/fraud-evaluation-metrics-policy.yaml
+++ b/config/resourcemetrics/fraud-evaluation-metrics-policy.yaml
@@ -1,0 +1,50 @@
+apiVersion: resourcemetrics.miloapis.com/v1alpha1
+kind: ResourceMetricsPolicy
+metadata:
+  name: fraud-evaluations
+spec:
+  generators:
+    - name: fraud-evaluation-info
+      resource:
+        group: fraud.miloapis.com
+        version: v1alpha1
+        resource: fraudevaluations
+      families:
+        - name: fraud_evaluation_info
+          help: "Metadata and current state of each FraudEvaluation. Value is always 1 — use labels to filter."
+          type: gauge
+          metrics:
+            - labels:
+                - name: name
+                  value: "object.metadata.name"
+                - name: user_ref
+                  value: "object.spec.userRef.name"
+                - name: phase
+                  value: "has(object.status.phase) ? object.status.phase : 'Unknown'"
+                - name: decision
+                  value: "has(object.status.decision) ? object.status.decision : ''"
+                - name: enforcement_action
+                  value: "has(object.status.enforcementAction) ? object.status.enforcementAction : ''"
+
+    - name: fraud-evaluation-conditions
+      resource:
+        group: fraud.miloapis.com
+        version: v1alpha1
+        resource: fraudevaluations
+      families:
+        - name: fraud_evaluation_status_condition
+          help: "Status condition state per FraudEvaluation. Value is 1 when the condition status is True, 0 otherwise."
+          type: gauge
+          metrics:
+            - value: "object.status.conditions.exists(c, c.type == 'Available' && c.status == 'True') ? 1.0 : 0.0"
+              labels:
+                - name: name
+                  value: "object.metadata.name"
+                - name: condition
+                  value: "'Available'"
+            - value: "object.status.conditions.exists(c, c.type == 'Degraded' && c.status == 'True') ? 1.0 : 0.0"
+              labels:
+                - name: name
+                  value: "object.metadata.name"
+                - name: condition
+                  value: "'Degraded'"

--- a/config/resourcemetrics/kustomization.yaml
+++ b/config/resourcemetrics/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - fraud-evaluation-metrics-policy.yaml

--- a/internal/controller/fraudevaluation_controller.go
+++ b/internal/controller/fraudevaluation_controller.go
@@ -296,12 +296,13 @@ func (r *FraudEvaluationReconciler) runProviders(
 
 		start := time.Now()
 		result := impl.Evaluate(ctx, input)
+		elapsed := time.Since(start)
 
 		pr := fraudv1alpha1.ProviderResult{
 			Provider:    sp.ProviderRef.Name,
 			Score:       strconv.FormatFloat(result.Score, 'f', 2, 64),
 			RawResponse: result.RawResponse,
-			Duration:    time.Since(start).Round(time.Millisecond).String(),
+			Duration:    elapsed.Round(time.Millisecond).String(),
 		}
 
 		if result.Error != nil {
@@ -312,7 +313,7 @@ func (r *FraudEvaluationReconciler) runProviders(
 
 			pr.Error = result.Error.Error()
 			pr.FailurePolicyApplied = failurePolicy
-			fraudmetrics.ProviderCallsTotal.WithLabelValues(sp.ProviderRef.Name, "failure").Inc()
+			fraudmetrics.ProviderCallDuration.WithLabelValues(sp.ProviderRef.Name, "failure").Observe(elapsed.Seconds())
 
 			if failurePolicy == "FailClosed" {
 				results = append(results, pr)
@@ -323,7 +324,7 @@ func (r *FraudEvaluationReconciler) runProviders(
 			degraded = true
 			log.Info("provider error with FailOpen policy, continuing", "provider", sp.ProviderRef.Name, "error", result.Error)
 		} else {
-			fraudmetrics.ProviderCallsTotal.WithLabelValues(sp.ProviderRef.Name, "success").Inc()
+			fraudmetrics.ProviderCallDuration.WithLabelValues(sp.ProviderRef.Name, "success").Observe(elapsed.Seconds())
 		}
 
 		results = append(results, pr)

--- a/internal/controller/fraudevaluation_controller.go
+++ b/internal/controller/fraudevaluation_controller.go
@@ -23,6 +23,7 @@ import (
 
 	fraudv1alpha1 "go.miloapis.com/fraud/api/v1alpha1"
 	"go.miloapis.com/fraud/internal/datasource"
+	fraudmetrics "go.miloapis.com/fraud/internal/metrics"
 	"go.miloapis.com/fraud/internal/provider"
 )
 
@@ -311,6 +312,7 @@ func (r *FraudEvaluationReconciler) runProviders(
 
 			pr.Error = result.Error.Error()
 			pr.FailurePolicyApplied = failurePolicy
+			fraudmetrics.ProviderCallsTotal.WithLabelValues(sp.ProviderRef.Name, "failure").Inc()
 
 			if failurePolicy == "FailClosed" {
 				results = append(results, pr)
@@ -320,6 +322,8 @@ func (r *FraudEvaluationReconciler) runProviders(
 			pr.Score = "0.00"
 			degraded = true
 			log.Info("provider error with FailOpen policy, continuing", "provider", sp.ProviderRef.Name, "error", result.Error)
+		} else {
+			fraudmetrics.ProviderCallsTotal.WithLabelValues(sp.ProviderRef.Name, "success").Inc()
 		}
 
 		results = append(results, pr)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -6,14 +6,17 @@ import (
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
-var ProviderCallsTotal = prometheus.NewCounterVec(
-	prometheus.CounterOpts{
-		Name: "fraud_provider_calls_total",
-		Help: "Total number of fraud provider calls, partitioned by provider name and result.",
+// ProviderCallDuration tracks the duration of fraud provider API calls.
+// The _count suffix gives call totals; use result="failure" to compute error rate.
+var ProviderCallDuration = prometheus.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name:    "fraud_provider_call_duration_seconds",
+		Help:    "Duration of fraud provider API calls in seconds, partitioned by provider and result.",
+		Buckets: []float64{0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 	},
 	[]string{"provider", "result"},
 )
 
 func init() {
-	ctrlmetrics.Registry.MustRegister(ProviderCallsTotal)
+	ctrlmetrics.Registry.MustRegister(ProviderCallDuration)
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var ProviderCallsTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "fraud_provider_calls_total",
+		Help: "Total number of fraud provider calls, partitioned by provider name and result.",
+	},
+	[]string{"provider", "result"},
+)
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(ProviderCallsTotal)
+}


### PR DESCRIPTION
## Summary

- Adds `fraud_provider_call_duration_seconds` histogram tracking call duration and count per provider and result (success/failure), enabling both error rate and latency alerting
- Adds `config/deploy/` kustomization for GKE control plane deployments — same footprint as `config/manager/` plus metrics service and monitoring components, without CRDs or RBAC
- Adds `config/prometheus/` component wiring in: `ServiceMonitor`, `VMServiceScrape`, `PrometheusRule` (generic), and `VMRule` (VictoriaMetrics) with five alerts
- Adds `config/resourcemetrics/` component with a `ResourceMetricsPolicy` emitting `fraud_evaluation_info` and `fraud_evaluation_status_condition` per evaluation

## Alerts

| Alert | Severity | Condition |
|---|---|---|
| FraudOperatorDown | critical | Operator unreachable for 5m |
| FraudProviderHighErrorRate | critical | >10% provider call failures for 5m |
| FraudProviderHighLatency | warning | p99 latency >5s for 5m |
| FraudEvaluationHighReconcileErrors | warning | >10% reconcile errors for 10m |
| FraudEvaluationsStuckInError | warning | Any evaluation in Error phase for 15m |
| FraudEvaluationDegraded | warning | Any evaluation with Degraded condition for 5m |

## Test plan

- [ ] Verify `fraud_provider_call_duration_seconds` appears in `/metrics` after a fraud evaluation runs
- [ ] Confirm `result="failure"` is incremented when MaxMind is unreachable
- [ ] Confirm p99 latency is observable via `histogram_quantile`
- [ ] Apply the `config/resourcemetrics/` component and verify `fraud_evaluation_info` and `fraud_evaluation_status_condition` are emitted
- [ ] Apply the `config/prometheus/` component and verify all alert rules load