### PR TITLE
feat: add VMRule, deploy kustomization, and complete alert coverage

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -28,8 +28,7 @@ components:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-- ../prometheus
-- ../resourcemetrics
+#- ../prometheus
 # [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
 # Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
 # Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -28,7 +28,8 @@ components:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
+- ../prometheus
+- ../resourcemetrics
 # [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
 # Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
 # Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will

--- a/config/deploy/kustomization.yaml
+++ b/config/deploy/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: fraud-system
+namePrefix: fraud-
+
+resources:
+  - ../rbac
+  - ../manager
+  - ../default/metrics_service.yaml
+
+components:
+  - ../prometheus
+  - ../resourcemetrics
+
+patches:
+  - path: ../default/manager_metrics_patch.yaml
+    target:
+      kind: Deployment

--- a/config/deploy/kustomization.yaml
+++ b/config/deploy/kustomization.yaml
@@ -10,7 +10,6 @@ resources:
 
 components:
   - ../prometheus
-  - ../resourcemetrics
 
 patches:
   - path: manager_metrics_patch.yaml

--- a/config/deploy/kustomization.yaml
+++ b/config/deploy/kustomization.yaml
@@ -5,7 +5,6 @@ namespace: fraud-system
 namePrefix: fraud-
 
 resources:
-  - ../rbac
   - ../manager
   - ../default/metrics_service.yaml
 

--- a/config/deploy/kustomization.yaml
+++ b/config/deploy/kustomization.yaml
@@ -6,13 +6,13 @@ namePrefix: fraud-
 
 resources:
   - ../manager
-  - ../default/metrics_service.yaml
+  - metrics_service.yaml
 
 components:
   - ../prometheus
   - ../resourcemetrics
 
 patches:
-  - path: ../default/manager_metrics_patch.yaml
+  - path: manager_metrics_patch.yaml
     target:
       kind: Deployment

--- a/config/deploy/manager_metrics_patch.yaml
+++ b/config/deploy/manager_metrics_patch.yaml
@@ -1,0 +1,4 @@
+# This patch adds the args to allow exposing the metrics endpoint using HTTPS
+- op: add
+  path: /spec/template/spec/containers/0/args/0
+  value: --metrics-bind-address=:8443

--- a/config/deploy/metrics_service.yaml
+++ b/config/deploy/metrics_service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: fraud
+    app.kubernetes.io/managed-by: kustomize
+  name: controller-manager-metrics-service
+  namespace: system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    control-plane: controller-manager
+    app.kubernetes.io/name: fraud

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
 resources:
 - monitor.yaml
 - vmservicescrape.yaml

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -2,6 +2,7 @@ resources:
 - monitor.yaml
 - vmservicescrape.yaml
 - alerts.yaml
+- vmrule.yaml
 
 # [PROMETHEUS-WITH-CERTS] The following patch configures the ServiceMonitor in ../prometheus
 # to securely reference certificates created and managed by cert-manager.

--- a/config/prometheus/vmrule.yaml
+++ b/config/prometheus/vmrule.yaml
@@ -1,5 +1,5 @@
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
 metadata:
   name: fraud-alerts
   namespace: system
@@ -9,6 +9,7 @@ metadata:
 spec:
   groups:
     - name: fraud-operator
+      interval: 30s
       rules:
         - alert: FraudOperatorDown
           expr: |
@@ -32,7 +33,7 @@ spec:
             severity: critical
           annotations:
             summary: "High error rate for fraud provider {{ $labels.provider }}"
-            description: "{{ $value | humanizePercentage }} of calls to provider {{ $labels.provider }} are failing. With FailClosed policy, fraud evaluations will be blocked until this is resolved."
+            description: "{{ $value | humanizePercentage }} of calls to provider {{ $labels.provider }} are failing. With FailClosed policy, evaluations will be blocked until this is resolved."
 
         - alert: FraudProviderHighLatency
           expr: |
@@ -46,8 +47,6 @@ spec:
             summary: "High latency for fraud provider {{ $labels.provider }}"
             description: "P99 latency for provider {{ $labels.provider }} is {{ $value }}s, exceeding the 5s threshold."
 
-    - name: fraud-evaluations
-      rules:
         - alert: FraudEvaluationHighReconcileErrors
           expr: |
             (
@@ -62,6 +61,9 @@ spec:
             summary: "High reconciliation error rate for fraud evaluations"
             description: "{{ $value | humanizePercentage }} of fraud evaluation reconciliations are failing."
 
+    - name: fraud-evaluations
+      interval: 30s
+      rules:
         - alert: FraudEvaluationsStuckInError
           expr: |
             count(fraud_evaluation_info{phase="Error"}) > 0


### PR DESCRIPTION
## Summary

- Adds `config/deploy/kustomization.yaml` — a GKE-specific kustomization that deploys the manager and monitoring components without CRDs or RBAC (those belong on the Milo control plane)
- Adds `config/prometheus/vmrule.yaml` — VictoriaMetrics VMRule with all operator and evaluation alerts, mirroring the PrometheusRule for users on VM stacks
- Extends `config/prometheus/alerts.yaml` with `FraudOperatorDown` (critical) and `FraudEvaluationHighReconcileErrors` (warning) alerts, completing alert coverage alongside the provider and evaluation-state alerts from #17

## Context

The `config/deploy/` overlay is intended for use by deployments where CRDs and RBAC are managed separately (e.g. via a Milo-targeted Kustomization). It wires in the `../prometheus` and `../resourcemetrics` components so monitoring is bundled with the deployment without requiring the full `config/default/` overlay.

The VMRule mirrors the PrometheusRule so teams using VictoriaMetrics can use `config/prometheus/` as a component and get alerts regardless of their metrics stack.

## Test plan

- [ ] `kustomize build config/deploy/` renders without CRD or RBAC resources
- [ ] `kustomize build config/prometheus/` includes both `PrometheusRule` and `VMRule`
- [ ] Alert expressions validated against `fraud_provider_call_duration_seconds`, `controller_runtime_reconcile_*`, and `fraud_evaluation_info` metrics