### PR TITLE
fix: use get-then-create for IAM enforcement resources

### DIFF
--- a/internal/controller/fraudevaluation_controller.go
+++ b/internal/controller/fraudevaluation_controller.go
@@ -504,8 +504,11 @@ func (r *FraudEvaluationReconciler) applyEnforcement(ctx context.Context, eval *
 		log.Info("PlatformAccessRejection ensured", "name", resourceName, "user", eval.Spec.UserRef.Name)
 
 	case fraudv1alpha1.DecisionAccepted:
-		var existing iamv1alpha1.PlatformAccessApproval
-		if err := r.Get(ctx, types.NamespacedName{Name: resourceName}, &existing); apierrors.IsNotFound(err) {
+		var paas iamv1alpha1.PlatformAccessApprovalList
+		if err := r.List(ctx, &paas, client.MatchingFields{"spec.subjectRef.userRef.name": eval.Spec.UserRef.Name}); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to list PlatformAccessApprovals for user %q: %w", eval.Spec.UserRef.Name, err)
+		}
+		if len(paas.Items) == 0 {
 			approval := &iamv1alpha1.PlatformAccessApproval{
 				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
 				Spec: iamv1alpha1.PlatformAccessApprovalSpec{
@@ -517,8 +520,6 @@ func (r *FraudEvaluationReconciler) applyEnforcement(ctx context.Context, eval *
 			if err := r.Create(ctx, approval); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to create PlatformAccessApproval %q: %w", resourceName, err)
 			}
-		} else if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to get PlatformAccessApproval %q: %w", resourceName, err)
 		}
 
 		log.Info("PlatformAccessApproval ensured", "name", resourceName, "user", eval.Spec.UserRef.Name)

--- a/internal/controller/fraudevaluation_controller.go
+++ b/internal/controller/fraudevaluation_controller.go
@@ -464,49 +464,61 @@ func (r *FraudEvaluationReconciler) applyEnforcement(ctx context.Context, eval *
 
 	switch eval.Status.Decision {
 	case fraudv1alpha1.DecisionDeactivate:
-		deactivation := &iamv1alpha1.UserDeactivation{
-			ObjectMeta: metav1.ObjectMeta{Name: resourceName},
-			Spec: iamv1alpha1.UserDeactivationSpec{
-				UserRef:       iamv1alpha1.UserReference{Name: eval.Spec.UserRef.Name},
-				Reason:        "fraud-deactivate",
-				Description:   fmt.Sprintf("Automated deactivation from FraudEvaluation %q (score: %s)", eval.Name, eval.Status.CompositeScore),
-				DeactivatedBy: "fraud-operator",
-			},
-		}
-
-		if err := r.Create(ctx, deactivation); err != nil && !apierrors.IsAlreadyExists(err) {
-			return ctrl.Result{}, fmt.Errorf("failed to create UserDeactivation %q: %w", resourceName, err)
+		var existing iamv1alpha1.UserDeactivation
+		if err := r.Get(ctx, types.NamespacedName{Name: resourceName}, &existing); apierrors.IsNotFound(err) {
+			deactivation := &iamv1alpha1.UserDeactivation{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+				Spec: iamv1alpha1.UserDeactivationSpec{
+					UserRef:       iamv1alpha1.UserReference{Name: eval.Spec.UserRef.Name},
+					Reason:        "fraud-deactivate",
+					Description:   fmt.Sprintf("Automated deactivation from FraudEvaluation %q (score: %s)", eval.Name, eval.Status.CompositeScore),
+					DeactivatedBy: "fraud-operator",
+				},
+			}
+			if err := r.Create(ctx, deactivation); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to create UserDeactivation %q: %w", resourceName, err)
+			}
+		} else if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to get UserDeactivation %q: %w", resourceName, err)
 		}
 
 		log.Info("UserDeactivation ensured", "name", resourceName, "user", eval.Spec.UserRef.Name)
 
 	case fraudv1alpha1.DecisionReview:
-		rejection := &iamv1alpha1.PlatformAccessRejection{
-			ObjectMeta: metav1.ObjectMeta{Name: resourceName},
-			Spec: iamv1alpha1.PlatformAccessRejectionSpec{
-				UserRef: iamv1alpha1.UserReference{Name: eval.Spec.UserRef.Name},
-				Reason:  "fraud-review",
-			},
-		}
-
-		if err := r.Create(ctx, rejection); err != nil && !apierrors.IsAlreadyExists(err) {
-			return ctrl.Result{}, fmt.Errorf("failed to create PlatformAccessRejection %q: %w", resourceName, err)
+		var existing iamv1alpha1.PlatformAccessRejection
+		if err := r.Get(ctx, types.NamespacedName{Name: resourceName}, &existing); apierrors.IsNotFound(err) {
+			rejection := &iamv1alpha1.PlatformAccessRejection{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+				Spec: iamv1alpha1.PlatformAccessRejectionSpec{
+					UserRef: iamv1alpha1.UserReference{Name: eval.Spec.UserRef.Name},
+					Reason:  "fraud-review",
+				},
+			}
+			if err := r.Create(ctx, rejection); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to create PlatformAccessRejection %q: %w", resourceName, err)
+			}
+		} else if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to get PlatformAccessRejection %q: %w", resourceName, err)
 		}
 
 		log.Info("PlatformAccessRejection ensured", "name", resourceName, "user", eval.Spec.UserRef.Name)
 
 	case fraudv1alpha1.DecisionAccepted:
-		approval := &iamv1alpha1.PlatformAccessApproval{
-			ObjectMeta: metav1.ObjectMeta{Name: resourceName},
-			Spec: iamv1alpha1.PlatformAccessApprovalSpec{
-				SubjectRef: iamv1alpha1.SubjectReference{
-					UserRef: &iamv1alpha1.UserReference{Name: eval.Spec.UserRef.Name},
+		var existing iamv1alpha1.PlatformAccessApproval
+		if err := r.Get(ctx, types.NamespacedName{Name: resourceName}, &existing); apierrors.IsNotFound(err) {
+			approval := &iamv1alpha1.PlatformAccessApproval{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+				Spec: iamv1alpha1.PlatformAccessApprovalSpec{
+					SubjectRef: iamv1alpha1.SubjectReference{
+						UserRef: &iamv1alpha1.UserReference{Name: eval.Spec.UserRef.Name},
+					},
 				},
-			},
-		}
-
-		if err := r.Create(ctx, approval); err != nil && !apierrors.IsAlreadyExists(err) {
-			return ctrl.Result{}, fmt.Errorf("failed to create PlatformAccessApproval %q: %w", resourceName, err)
+			}
+			if err := r.Create(ctx, approval); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to create PlatformAccessApproval %q: %w", resourceName, err)
+			}
+		} else if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to get PlatformAccessApproval %q: %w", resourceName, err)
 		}
 
 		log.Info("PlatformAccessApproval ensured", "name", resourceName, "user", eval.Spec.UserRef.Name)

--- a/internal/controller/fraudevaluation_controller_test.go
+++ b/internal/controller/fraudevaluation_controller_test.go
@@ -670,6 +670,76 @@ var _ = Describe("FraudEvaluation Controller", func() {
 			Expect(deactivationList.Items).To(HaveLen(1))
 		})
 
+		It("should not create a duplicate PlatformAccessApproval on re-reconcile", func() {
+			createResources(15, "FailOpen", "AUTO")
+
+			eval := &fraudv1alpha1.FraudEvaluation{
+				ObjectMeta: metav1.ObjectMeta{Name: "eval-paa-idem"},
+				Spec: fraudv1alpha1.FraudEvaluationSpec{
+					UserRef:   fraudv1alpha1.UserReference{Name: "user-paa-idem"},
+					PolicyRef: fraudv1alpha1.PolicyReference{Name: policyName},
+				},
+			}
+			Expect(k8sClient.Create(ctx, eval)).To(Succeed())
+
+			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "eval-paa-idem"}}
+
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Second reconcile: EnforcementApplied short-circuits; no second create attempted.
+			_, err = reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			paaList := &iamv1alpha1.PlatformAccessApprovalList{}
+			Expect(k8sClient.List(ctx, paaList)).To(Succeed())
+			Expect(paaList.Items).To(HaveLen(1))
+		})
+
+		It("should skip PAA creation if user already has an approval from a prior evaluation", func() {
+			createResources(15, "FailOpen", "AUTO")
+
+			// Pre-create a PAA for the user under a different name (simulating a prior evaluation).
+			prior := &iamv1alpha1.PlatformAccessApproval{
+				ObjectMeta: metav1.ObjectMeta{Name: "prior-eval-approval"},
+				Spec: iamv1alpha1.PlatformAccessApprovalSpec{
+					SubjectRef: iamv1alpha1.SubjectReference{
+						UserRef: &iamv1alpha1.UserReference{Name: "user-preapproved"},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, prior)).To(Succeed())
+
+			eval := &fraudv1alpha1.FraudEvaluation{
+				ObjectMeta: metav1.ObjectMeta{Name: "eval-preapproved"},
+				Spec: fraudv1alpha1.FraudEvaluationSpec{
+					UserRef:   fraudv1alpha1.UserReference{Name: "user-preapproved"},
+					PolicyRef: fraudv1alpha1.PolicyReference{Name: policyName},
+				},
+			}
+			Expect(k8sClient.Create(ctx, eval)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: "eval-preapproved"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "eval-preapproved"}, eval)).To(Succeed())
+			Expect(eval.Status.Phase).To(Equal(fraudv1alpha1.PhaseCompleted))
+			Expect(eval.Status.Decision).To(Equal(fraudv1alpha1.DecisionAccepted))
+
+			// Only the pre-existing PAA should be present — no new one created.
+			paaList := &iamv1alpha1.PlatformAccessApprovalList{}
+			Expect(k8sClient.List(ctx, paaList)).To(Succeed())
+			Expect(paaList.Items).To(HaveLen(1))
+			Expect(paaList.Items[0].Name).To(Equal("prior-eval-approval"))
+
+			// EnforcementApplied condition should still be set.
+			cond := findCondition(eval.Status.Conditions, conditionEnforcementApplied)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+		})
+
 		It("should set Error phase when provider is not registered", func() {
 			// Create resources but do NOT register anything in the registry.
 			fp := &fraudv1alpha1.FraudProvider{


### PR DESCRIPTION
## Summary

- Replaces create-and-ignore-AlreadyExists with GET-then-create for `UserDeactivation` and `PlatformAccessRejection`, so errors from admission webhooks surface correctly instead of being swallowed
- For `PlatformAccessApproval`, uses LIST filtered by `spec.subjectRef.userRef.name` (a server-side selectable field) before creating — the PAA webhook enforces subject-uniqueness across all approvals, so a same-name GET isn't sufficient; we need to check whether any PAA already exists for the user

## Test plan

- [ ] Evaluations with DEACTIVATE/REVIEW/ACCEPTED decisions reconcile without errors
- [ ] Re-reconciling a completed evaluation whose enforcement resource already exists skips creation and sets `EnforcementApplied`
- [ ] A user with an existing PlatformAccessApproval (from a prior evaluation) does not cause a new evaluation to error-loop