### PR TITLE
fix: rename metrics service port from https to metrics

### DIFF
--- a/config/default/metrics_service.yaml
+++ b/config/default/metrics_service.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: system
 spec:
   ports:
-  - name: https
+  - name: metrics
     port: 8443
     protocol: TCP
     targetPort: 8443

--- a/config/deploy/metrics_service.yaml
+++ b/config/deploy/metrics_service.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: system
 spec:
   ports:
-  - name: https
+  - name: metrics
     port: 8443
     protocol: TCP
     targetPort: 8443

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   endpoints:
     - path: /metrics
-      port: https # Ensure this is the name of the port that exposes HTTPS metrics
+      port: metrics # Ensure this is the name of the port that exposes metrics
       scheme: https
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:

--- a/config/prometheus/vmservicescrape.yaml
+++ b/config/prometheus/vmservicescrape.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   endpoints:
     - path: /metrics
-      port: https
+      port: metrics
       scheme: http
   selector:
     matchLabels:


### PR DESCRIPTION
## Summary

- Renames the metrics Service port from `https` to `metrics` in both `config/default/metrics_service.yaml` and `config/deploy/metrics_service.yaml`
- Updates `VMServiceScrape` and `ServiceMonitor` to reference the new port name `metrics`

## Root cause

The fraud operator runs with `--metrics-secure=false`, serving plain HTTP on port 8443. The `VMServiceScrape` correctly sets `scheme: http`, but the VM operator was intermittently generating `https://` scrape URLs, causing VMAgent to fail with:

```
http: server gave HTTP response to HTTPS client
```

This triggered the `FraudOperatorDown` alert every ~10 minutes (aligned with the `fraud-manager` Kustomization reconciliation cycle), resolving 7 minutes later when the VM operator re-reconciled and restored `scheme: http`.

The root cause is that the VM operator uses the port **name** as a hint for the scheme when generating VMAgent scrape configs. A port named `https` causes it to override the explicit `scheme: http` field on some reconcile passes. Renaming the port to `metrics` removes this ambiguity.

## Test plan
- [ ] After deploy to staging, confirm VMAgent scrape config Secret contains `http://` scheme for the fraud metrics endpoint
- [ ] Confirm `FraudOperatorDown` alert stops firing on the ~10m cadence
- [ ] Confirm `up{job="fraud-controller-manager-metrics-service"}` remains `1`