### PR TITLE
fix: register PlatformAccessApproval field index for cache lookup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,18 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	@out="$$( $(KUSTOMIZE) build config/crd 2>/dev/null || true )"; \
 	if [ -n "$$out" ]; then echo "$$out" | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -; else echo "No CRDs to delete; skipping."; fi
 
+# MILO_REF pins the milo branch/tag/SHA used to fetch IAM CRDs for e2e tests.
+MILO_REF ?= main
+MILO_IAM_CRDS_URL ?= https://github.com/datum-cloud/milo//config/crd/bases/iam?ref=$(MILO_REF)
+
+.PHONY: install-milo-crds
+install-milo-crds: ## Install milo IAM CRDs (PlatformAccessApproval, etc.) needed by the controller cache informers in e2e.
+	$(KUBECTL) apply -k $(MILO_IAM_CRDS_URL)
+
+.PHONY: uninstall-milo-crds
+uninstall-milo-crds: ## Uninstall milo IAM CRDs. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+	$(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -k $(MILO_IAM_CRDS_URL)
+
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}

--- a/internal/controller/fraudevaluation_controller.go
+++ b/internal/controller/fraudevaluation_controller.go
@@ -565,6 +565,30 @@ func (r *FraudEvaluationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	); err != nil {
 		return err
 	}
+
+	// applyEnforcement uses client.MatchingFields on PlatformAccessApproval to
+	// detect whether an approval already exists for the user before creating
+	// one. The cached client requires a registered IndexField for that lookup,
+	// even though spec.subjectRef.userRef.name is already a server-side
+	// selectable field on the CRD.
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(),
+		&iamv1alpha1.PlatformAccessApproval{},
+		"spec.subjectRef.userRef.name",
+		func(obj client.Object) []string {
+			paa, ok := obj.(*iamv1alpha1.PlatformAccessApproval)
+			if !ok {
+				return nil
+			}
+			if paa.Spec.SubjectRef.UserRef == nil {
+				return nil
+			}
+			return []string{paa.Spec.SubjectRef.UserRef.Name}
+		},
+	); err != nil {
+		return fmt.Errorf("failed to set field index on PlatformAccessApproval: %w", err)
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&fraudv1alpha1.FraudEvaluation{}).
 		Named("fraudevaluation").

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -47,6 +47,11 @@ var _ = Describe("Fraud Operator", Ordered, func() {
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
 
+		By("installing milo IAM CRDs (PlatformAccessApproval, etc.)")
+		cmd = exec.Command("make", "install-milo-crds")
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to install milo IAM CRDs")
+
 		By("deploying the controller-manager")
 		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
 		_, err = utils.Run(cmd)
@@ -79,6 +84,10 @@ var _ = Describe("Fraud Operator", Ordered, func() {
 
 		By("uninstalling CRDs")
 		cmd = exec.Command("make", "uninstall", "ignore-not-found=true")
+		_, _ = utils.Run(cmd)
+
+		By("uninstalling milo IAM CRDs")
+		cmd = exec.Command("make", "uninstall-milo-crds", "ignore-not-found=true")
 		_, _ = utils.Run(cmd)
 
 		By("cleaning up e2e credentials secret")


### PR DESCRIPTION
## Summary

- Restore the \`spec.subjectRef.userRef.name\` field index registration on \`PlatformAccessApproval\` in \`FraudEvaluationReconciler.SetupWithManager\`.

## Background

\`applyEnforcement\` uses \`client.MatchingFields{\"spec.subjectRef.userRef.name\": ...}\` on \`PlatformAccessApproval\` to detect whether an approval already exists for the user before creating one. This was re-introduced in 07b1ceb (\"fix: list PAAs by user before creating to respect subject uniqueness\"), but the matching \`IndexField\` registration — originally added in 5f02a1c — was dropped during prior revert chains and never restored when the \`MatchingFields\` lookup came back.

The CRD declares \`spec.subjectRef.userRef.name\` as a \`+kubebuilder:selectablefield\`, but that only enables the field as a server-side field selector. controller-runtime's cached client also requires a locally registered \`IndexField\` for any \`MatchingFields\` lookup against the informer cache.

## Symptom in staging

100% of \`fraudevaluation\` reconciliations failing with:

```
failed to list PlatformAccessApprovals for user \"...\": Index with name field:spec.subjectRef.userRef.name does not exist
```

Firing \`FraudEvaluationHighReconcileErrors\` on the staging Slack channel.

## Test plan

- [x] \`go build ./...\` and \`go vet ./internal/controller/\` clean.
- [x] After merge & deploy, confirm the \`fraudevaluation\` controller's reconcile error rate drops back to ~0.
- [x] Note: existing tests use envtest's uncached \`k8sClient\` so they don't exercise the cached-client path. A proper regression test would need a manager-backed reconciler — out of scope for this hot-fix but worth a follow-up.