### PR TITLE
fix: skip PAA when PAR exists; REVIEW defers to humans instead of auto-creating PAR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,22 +199,14 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 # MILO_REF pins the milo branch/tag/SHA used to fetch IAM CRDs for e2e tests.
 MILO_REF ?= main
 MILO_IAM_CRDS_URL ?= https://github.com/datum-cloud/milo//config/crd/bases/iam?ref=$(MILO_REF)
-MILO_RAW_BASE ?= https://raw.githubusercontent.com/datum-cloud/milo/$(MILO_REF)/config/crd/bases/iam
-
-# Milo's iam kustomization.yaml currently omits PlatformAccessRejection (and a
-# few others), so we apply the rejection CRD directly. Drop this once milo
-# adds it to the kustomization.
-MILO_EXTRA_CRDS ?= $(MILO_RAW_BASE)/iam.miloapis.com_platformaccessrejections.yaml
 
 .PHONY: install-milo-crds
 install-milo-crds: ## Install milo IAM CRDs (PlatformAccessApproval, PlatformAccessRejection, etc.) needed by the controller cache informers in e2e.
 	$(KUBECTL) apply -k $(MILO_IAM_CRDS_URL)
-	$(KUBECTL) apply -f $(MILO_EXTRA_CRDS)
 
 .PHONY: uninstall-milo-crds
 uninstall-milo-crds: ## Uninstall milo IAM CRDs. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -k $(MILO_IAM_CRDS_URL)
-	$(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f $(MILO_EXTRA_CRDS)
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.

--- a/Makefile
+++ b/Makefile
@@ -199,14 +199,22 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 # MILO_REF pins the milo branch/tag/SHA used to fetch IAM CRDs for e2e tests.
 MILO_REF ?= main
 MILO_IAM_CRDS_URL ?= https://github.com/datum-cloud/milo//config/crd/bases/iam?ref=$(MILO_REF)
+MILO_RAW_BASE ?= https://raw.githubusercontent.com/datum-cloud/milo/$(MILO_REF)/config/crd/bases/iam
+
+# Milo's iam kustomization.yaml currently omits PlatformAccessRejection (and a
+# few others), so we apply the rejection CRD directly. Drop this once milo
+# adds it to the kustomization.
+MILO_EXTRA_CRDS ?= $(MILO_RAW_BASE)/iam.miloapis.com_platformaccessrejections.yaml
 
 .PHONY: install-milo-crds
-install-milo-crds: ## Install milo IAM CRDs (PlatformAccessApproval, etc.) needed by the controller cache informers in e2e.
+install-milo-crds: ## Install milo IAM CRDs (PlatformAccessApproval, PlatformAccessRejection, etc.) needed by the controller cache informers in e2e.
 	$(KUBECTL) apply -k $(MILO_IAM_CRDS_URL)
+	$(KUBECTL) apply -f $(MILO_EXTRA_CRDS)
 
 .PHONY: uninstall-milo-crds
 uninstall-milo-crds: ## Uninstall milo IAM CRDs. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -k $(MILO_IAM_CRDS_URL)
+	$(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f $(MILO_EXTRA_CRDS)
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -71,17 +71,12 @@ rules:
   - iam.miloapis.com
   resources:
   - platformaccessapprovals
-  verbs:
-  - create
-  - get
-  - list
-- apiGroups:
-  - iam.miloapis.com
-  resources:
   - platformaccessrejections
   verbs:
   - create
   - get
+  - list
+  - watch
 - apiGroups:
   - iam.miloapis.com
   resources:

--- a/internal/controller/fraudevaluation_controller.go
+++ b/internal/controller/fraudevaluation_controller.go
@@ -486,23 +486,15 @@ func (r *FraudEvaluationReconciler) applyEnforcement(ctx context.Context, eval *
 		log.Info("UserDeactivation ensured", "name", resourceName, "user", eval.Spec.UserRef.Name)
 
 	case fraudv1alpha1.DecisionReview:
-		var existing iamv1alpha1.PlatformAccessRejection
-		if err := r.Get(ctx, types.NamespacedName{Name: resourceName}, &existing); apierrors.IsNotFound(err) {
-			rejection := &iamv1alpha1.PlatformAccessRejection{
-				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
-				Spec: iamv1alpha1.PlatformAccessRejectionSpec{
-					UserRef: iamv1alpha1.UserReference{Name: eval.Spec.UserRef.Name},
-					Reason:  "fraud-review",
-				},
-			}
-			if err := r.Create(ctx, rejection); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to create PlatformAccessRejection %q: %w", resourceName, err)
-			}
-		} else if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to get PlatformAccessRejection %q: %w", resourceName, err)
-		}
-
-		log.Info("PlatformAccessRejection ensured", "name", resourceName, "user", eval.Spec.UserRef.Name)
+		// REVIEW means the evaluation needs human attention — it does not
+		// automatically translate to a denial. Surface the state via the
+		// EnforcementApplied condition and leave any IAM action to an admin.
+		log.Info("review decision requires manual action; no IAM resource created",
+			"user", eval.Spec.UserRef.Name)
+		return r.setEnforcementAppliedCondition(
+			ctx, eval, "ReviewRequired",
+			fmt.Sprintf("Enforcement deferred: evaluation requires manual review for user %q", eval.Spec.UserRef.Name),
+		)
 
 	case fraudv1alpha1.DecisionAccepted:
 		// The IAM admission webhook denies PlatformAccessApproval creation if a

--- a/internal/controller/fraudevaluation_controller.go
+++ b/internal/controller/fraudevaluation_controller.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -504,6 +505,30 @@ func (r *FraudEvaluationReconciler) applyEnforcement(ctx context.Context, eval *
 		log.Info("PlatformAccessRejection ensured", "name", resourceName, "user", eval.Spec.UserRef.Name)
 
 	case fraudv1alpha1.DecisionAccepted:
+		// The IAM admission webhook denies PlatformAccessApproval creation if a
+		// PlatformAccessRejection already exists for the same subject. Check for
+		// one first and skip approval creation rather than retry-looping. The
+		// rejection may be intentional (admin-owned or from a prior REVIEW
+		// evaluation) so we do not auto-delete it — surface the conflict and
+		// require manual reconciliation.
+		var rejections iamv1alpha1.PlatformAccessRejectionList
+		if err := r.List(ctx, &rejections, client.MatchingFields{"spec.subjectRef.name": eval.Spec.UserRef.Name}); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to list PlatformAccessRejections for user %q: %w", eval.Spec.UserRef.Name, err)
+		}
+		if len(rejections.Items) > 0 {
+			rejectionNames := make([]string, 0, len(rejections.Items))
+			for i := range rejections.Items {
+				rejectionNames = append(rejectionNames, rejections.Items[i].Name)
+			}
+			log.Info("skipping PlatformAccessApproval creation: rejection already exists for user",
+				"user", eval.Spec.UserRef.Name,
+				"rejections", rejectionNames)
+			return r.setEnforcementAppliedCondition(
+				ctx, eval, "RejectionExists",
+				fmt.Sprintf("Enforcement skipped: existing PlatformAccessRejection(s) for user %q: %s", eval.Spec.UserRef.Name, strings.Join(rejectionNames, ", ")),
+			)
+		}
+
 		var paas iamv1alpha1.PlatformAccessApprovalList
 		if err := r.List(ctx, &paas, client.MatchingFields{"spec.subjectRef.userRef.name": eval.Spec.UserRef.Name}); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to list PlatformAccessApprovals for user %q: %w", eval.Spec.UserRef.Name, err)
@@ -587,6 +612,26 @@ func (r *FraudEvaluationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		},
 	); err != nil {
 		return fmt.Errorf("failed to set field index on PlatformAccessApproval: %w", err)
+	}
+
+	// applyEnforcement also uses client.MatchingFields on PlatformAccessRejection
+	// to detect whether a rejection already exists for the user before attempting
+	// to create an approval (which the IAM admission webhook would otherwise
+	// deny). Note the field path is the flat spec.subjectRef.name — different
+	// from PAA's nested spec.subjectRef.userRef.name.
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(),
+		&iamv1alpha1.PlatformAccessRejection{},
+		"spec.subjectRef.name",
+		func(obj client.Object) []string {
+			par, ok := obj.(*iamv1alpha1.PlatformAccessRejection)
+			if !ok {
+				return nil
+			}
+			return []string{par.Spec.UserRef.Name}
+		},
+	); err != nil {
+		return fmt.Errorf("failed to set field index on PlatformAccessRejection: %w", err)
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/fraudevaluation_controller.go
+++ b/internal/controller/fraudevaluation_controller.go
@@ -74,8 +74,8 @@ type FraudEvaluationReconciler struct {
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=iam.miloapis.com,resources=users,verbs=get
 // +kubebuilder:rbac:groups=iam.miloapis.com,resources=userdeactivations,verbs=get;create;update;patch
-// +kubebuilder:rbac:groups=iam.miloapis.com,resources=platformaccessapprovals,verbs=get;list;create
-// +kubebuilder:rbac:groups=iam.miloapis.com,resources=platformaccessrejections,verbs=get;create
+// +kubebuilder:rbac:groups=iam.miloapis.com,resources=platformaccessapprovals,verbs=get;list;watch;create
+// +kubebuilder:rbac:groups=iam.miloapis.com,resources=platformaccessrejections,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups=activity.miloapis.com,resources=auditlogqueries,verbs=create
 
 // Reconcile runs the fraud evaluation pipeline for a FraudEvaluation resource.

--- a/internal/controller/fraudevaluation_controller_test.go
+++ b/internal/controller/fraudevaluation_controller_test.go
@@ -562,7 +562,7 @@ var _ = Describe("FraudEvaluation Controller", func() {
 			Expect(eval.Status.History).To(HaveLen(1))
 		})
 
-		It("AUTO mode REVIEW decision should create PlatformAccessRejection", func() {
+		It("AUTO mode REVIEW decision should defer enforcement, not create a PlatformAccessRejection", func() {
 			createResources(75, "FailOpen", "AUTO")
 
 			eval := &fraudv1alpha1.FraudEvaluation{
@@ -582,10 +582,16 @@ var _ = Describe("FraudEvaluation Controller", func() {
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "eval-review-auto"}, eval)).To(Succeed())
 			Expect(eval.Status.Decision).To(Equal(fraudv1alpha1.DecisionReview))
 
-			rejection := &iamv1alpha1.PlatformAccessRejection{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "fraud-eval-review-auto"}, rejection)).To(Succeed())
-			Expect(rejection.Spec.UserRef.Name).To(Equal("user-review"))
-			Expect(rejection.Spec.Reason).To(Equal("fraud-review"))
+			// No PAR should be created — REVIEW now defers to human review.
+			parList := &iamv1alpha1.PlatformAccessRejectionList{}
+			Expect(k8sClient.List(ctx, parList)).To(Succeed())
+			Expect(parList.Items).To(BeEmpty())
+
+			// EnforcementApplied condition should reflect the deferral.
+			cond := findCondition(eval.Status.Conditions, conditionEnforcementApplied)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal("ReviewRequired"))
 		})
 
 		It("AUTO mode ACCEPTED decision should create PlatformAccessApproval", func() {

--- a/internal/controller/fraudevaluation_controller_test.go
+++ b/internal/controller/fraudevaluation_controller_test.go
@@ -740,6 +740,52 @@ var _ = Describe("FraudEvaluation Controller", func() {
 			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 		})
 
+		It("should skip PAA creation if user already has a PlatformAccessRejection", func() {
+			createResources(15, "FailOpen", "AUTO")
+
+			// Pre-create a rejection for the user (e.g. from a prior REVIEW
+			// evaluation or admin action). The IAM webhook would block any
+			// PAA create for the same subject; the controller must detect
+			// this and skip rather than retry-loop.
+			rejection := &iamv1alpha1.PlatformAccessRejection{
+				ObjectMeta: metav1.ObjectMeta{Name: "prior-eval-rejection"},
+				Spec: iamv1alpha1.PlatformAccessRejectionSpec{
+					UserRef: iamv1alpha1.UserReference{Name: "user-prerejected"},
+					Reason:  "fraud-review",
+				},
+			}
+			Expect(k8sClient.Create(ctx, rejection)).To(Succeed())
+
+			eval := &fraudv1alpha1.FraudEvaluation{
+				ObjectMeta: metav1.ObjectMeta{Name: "eval-prerejected"},
+				Spec: fraudv1alpha1.FraudEvaluationSpec{
+					UserRef:   fraudv1alpha1.UserReference{Name: "user-prerejected"},
+					PolicyRef: fraudv1alpha1.PolicyReference{Name: policyName},
+				},
+			}
+			Expect(k8sClient.Create(ctx, eval)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: "eval-prerejected"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "eval-prerejected"}, eval)).To(Succeed())
+			Expect(eval.Status.Decision).To(Equal(fraudv1alpha1.DecisionAccepted))
+
+			// No PAA should have been created.
+			paaList := &iamv1alpha1.PlatformAccessApprovalList{}
+			Expect(k8sClient.List(ctx, paaList)).To(Succeed())
+			Expect(paaList.Items).To(BeEmpty())
+
+			// EnforcementApplied condition should be set with RejectionExists reason.
+			cond := findCondition(eval.Status.Conditions, conditionEnforcementApplied)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal("RejectionExists"))
+			Expect(cond.Message).To(ContainSubstring("prior-eval-rejection"))
+		})
+
 		It("should set Error phase when provider is not registered", func() {
 			// Create resources but do NOT register anything in the registry.
 			fp := &fraudv1alpha1.FraudProvider{

--- a/internal/controller/fraudevaluation_controller_test.go
+++ b/internal/controller/fraudevaluation_controller_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
@@ -17,16 +18,6 @@ import (
 	fraudv1alpha1 "go.miloapis.com/fraud/api/v1alpha1"
 	"go.miloapis.com/fraud/internal/provider"
 )
-
-// findCondition returns the condition with the given type, or nil if not found.
-func findCondition(conditions []metav1.Condition, condType string) *metav1.Condition {
-	for i := range conditions {
-		if conditions[i].Type == condType {
-			return &conditions[i]
-		}
-	}
-	return nil
-}
 
 // mockProvider is a test implementation of provider.Provider.
 type mockProvider struct {
@@ -588,7 +579,7 @@ var _ = Describe("FraudEvaluation Controller", func() {
 			Expect(parList.Items).To(BeEmpty())
 
 			// EnforcementApplied condition should reflect the deferral.
-			cond := findCondition(eval.Status.Conditions, conditionEnforcementApplied)
+			cond := meta.FindStatusCondition(eval.Status.Conditions, conditionEnforcementApplied)
 			Expect(cond).NotTo(BeNil())
 			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 			Expect(cond.Reason).To(Equal("ReviewRequired"))
@@ -644,7 +635,7 @@ var _ = Describe("FraudEvaluation Controller", func() {
 
 			// EnforcementApplied condition should still be set with ObserveMode reason.
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "eval-observe-noiam"}, eval)).To(Succeed())
-			cond := findCondition(eval.Status.Conditions, conditionEnforcementApplied)
+			cond := meta.FindStatusCondition(eval.Status.Conditions, conditionEnforcementApplied)
 			Expect(cond).NotTo(BeNil())
 			Expect(cond.Reason).To(Equal("ObserveMode"))
 		})
@@ -741,7 +732,7 @@ var _ = Describe("FraudEvaluation Controller", func() {
 			Expect(paaList.Items[0].Name).To(Equal("prior-eval-approval"))
 
 			// EnforcementApplied condition should still be set.
-			cond := findCondition(eval.Status.Conditions, conditionEnforcementApplied)
+			cond := meta.FindStatusCondition(eval.Status.Conditions, conditionEnforcementApplied)
 			Expect(cond).NotTo(BeNil())
 			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 		})
@@ -785,7 +776,7 @@ var _ = Describe("FraudEvaluation Controller", func() {
 			Expect(paaList.Items).To(BeEmpty())
 
 			// EnforcementApplied condition should be set with RejectionExists reason.
-			cond := findCondition(eval.Status.Conditions, conditionEnforcementApplied)
+			cond := meta.FindStatusCondition(eval.Status.Conditions, conditionEnforcementApplied)
 			Expect(cond).NotTo(BeNil())
 			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 			Expect(cond.Reason).To(Equal("RejectionExists"))


### PR DESCRIPTION
Fixes #24

Two related changes in `applyEnforcement`:

## 1. ACCEPTED: skip PAA creation if a PlatformAccessRejection exists

The IAM admission webhook denies PAA creation if a PAR already exists for the same subject (verified: `milo/internal/webhooks/iam/v1alpha1/platformaccessapproval_webhook.go:166-174`). Without detecting this, the reconcile retries forever and drives `FraudEvaluationHighReconcileErrors`.

Before creating a PAA, list PARs filtered by `spec.subjectRef.name` (server-side selectable on the CRD; new local `IndexField` registered in `SetupWithManager` so the cached client can resolve it — same pattern as #23). If any exist, skip and set `EnforcementApplied` with reason `RejectionExists` listing the conflicting rejection name(s).

The PAR is intentionally **not** auto-deleted — observed in prod the blocking PARs are admin-created (e.g. `platform-access-rejection-nr5rd` reason "Looks like spam account"); fraud should not silently override them.

## 2. REVIEW: defer to humans, don't auto-create a PAR

The `DecisionReview` branch was creating a PAR named `fraud-eval-<name>` with reason `"fraud-review"`. REVIEW semantically means "this needs a human to look at" — not "deny". Auto-creating a rejection silently denies the user and also self-conflicts with #1 above on any later ACCEPTED eval for the same user.

Replace the PAR creation with `setEnforcementAppliedCondition(reason: "ReviewRequired", message: ...)`. Admins can then create a PAA / PAR / UserDeactivation themselves based on judgment.

### Bonus: also clears a separate prod error

The same change fixes the second error class observed in prod logs:

```
failed to create PlatformAccessRejection "fraud-eval-gvr4q": admission webhook
"mplatformaccessrejection.iam.miloapis.com" denied: failed to get user '' from
iam.miloapis.com API: User.iam.miloapis.com "" not found
```

Despite the message ("user ''"), this isn't about an empty `userRef` on the FraudEvaluation. The PAR mutating webhook (`platformaccessarejection_webhook.go:55`) tries to look up the **requester** via `req.UserInfo.UID` to populate `spec.rejecterRef`. The fraud-operator's service account doesn't map to a `User.iam.miloapis.com` resource, so the lookup fails. Since this PR removes all PAR creates from the controller, this error class disappears too.

Existing `fraud-eval-*` PARs created by older controller versions are **not** auto-cleaned — admins should review and remove them as desired.

## Test plan

- [x] New unit test: `should skip PAA creation if user already has a PlatformAccessRejection`
- [x] Updated unit test: `AUTO mode REVIEW decision should defer enforcement, not create a PlatformAccessRejection` (asserts no PAR created + `ReviewRequired` condition)
- [x] Full controller suite: 25/25 specs pass
- [x] `go build ./...` and `go vet ./...` clean
- [x] Verified the prod errors against milo webhook source (PAA validator denies on existing PAR; PAR mutating webhook fails on empty requester)
- [ ] After merge & deploy to prod, confirm both error classes disappear from the fraud controller log
