### PR TITLE
fix: stop bricking ACCEPTED evals via stale post-Update cache read

### DIFF
--- a/internal/controller/fraudevaluation_controller.go
+++ b/internal/controller/fraudevaluation_controller.go
@@ -108,10 +108,11 @@ func (r *FraudEvaluationReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return r.applyEnforcement(ctx, &eval, &policy)
 	}
 
-	// 3. Set phase to Running and update status.
+	// 3. Set phase to Running.
 	if eval.Status.Phase != fraudv1alpha1.PhaseRunning {
+		base := eval.DeepCopy()
 		eval.Status.Phase = fraudv1alpha1.PhaseRunning
-		if err := r.Status().Update(ctx, &eval); err != nil {
+		if err := r.Status().Patch(ctx, &eval, client.MergeFrom(base)); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to set phase to Running: %w", err)
 		}
 	}
@@ -151,11 +152,9 @@ func (r *FraudEvaluationReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// 8. Determine enforcement action based on policy mode.
 	enforcementAction := r.determineEnforcement(policy.Spec.Enforcement.Mode, decision)
 
-	// 9. Add to history (prepend, trim to maxEntries).
+	// 9. Compute the new history entry (don't mutate eval yet).
 	now := metav1.Now()
-
 	compositeScoreStr := strconv.FormatFloat(compositeScore, 'f', 2, 64)
-
 	historyEntry := fraudv1alpha1.HistoryEntry{
 		Timestamp:      now,
 		CompositeScore: compositeScoreStr,
@@ -163,12 +162,16 @@ func (r *FraudEvaluationReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		Trigger:        eval.Status.Trigger,
 	}
 
+	// 10. Snapshot the pre-mutation state, then apply all status mutations and
+	// patch them atomically. The base must be captured before ANY status
+	// modifications below, otherwise client.MergeFrom won't include the
+	// pre-snapshot mutations in the diff and they'll silently be dropped.
+	base := eval.DeepCopy()
+
 	eval.Status.History = append([]fraudv1alpha1.HistoryEntry{historyEntry}, eval.Status.History...)
 	if len(eval.Status.History) > maxEntries {
 		eval.Status.History = eval.Status.History[:maxEntries]
 	}
-
-	// 10. Set phase to Completed and update all status fields.
 	eval.Status.Phase = fraudv1alpha1.PhaseCompleted
 	eval.Status.CompositeScore = compositeScoreStr
 	eval.Status.Decision = decision
@@ -184,8 +187,8 @@ func (r *FraudEvaluationReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		ObservedGeneration: eval.Generation,
 	})
 
-	if err := r.Status().Update(ctx, &eval); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to update status to Completed: %w", err)
+	if err := r.Status().Patch(ctx, &eval, client.MergeFrom(base)); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to patch status to Completed: %w", err)
 	}
 
 	log.Info("evaluation completed",
@@ -194,12 +197,14 @@ func (r *FraudEvaluationReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		"enforcementAction", enforcementAction,
 		"stages", len(stageResults))
 
-	// 11. Re-fetch to get the latest resourceVersion before patching status again.
-	if err := r.Get(ctx, req.NamespacedName, &eval); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to re-fetch FraudEvaluation after completion: %w", err)
-	}
-
-	// 12. Apply enforcement based on policy mode and decision.
+	// 11. Apply enforcement based on policy mode and decision. Use the
+	// in-memory eval — the patch above populated ResourceVersion in place,
+	// so the patch in setEnforcementAppliedCondition will target the correct
+	// revision. We deliberately do NOT re-Get from the cache here: the watch
+	// event for the patch above may not have propagated yet, and a stale read
+	// with decision="" would push applyEnforcement into the default branch
+	// and permanently mark the eval EnforcementApplied=SkippedUnknownDecision,
+	// blocking all future retries.
 	return r.applyEnforcement(ctx, &eval, &policy)
 }
 
@@ -427,6 +432,8 @@ func (r *FraudEvaluationReconciler) setErrorPhase(ctx context.Context, eval *fra
 	log := logf.FromContext(ctx)
 	log.Error(fmt.Errorf("%s", message), "evaluation failed")
 
+	base := eval.DeepCopy()
+
 	eval.Status.Phase = fraudv1alpha1.PhaseError
 
 	meta.SetStatusCondition(&eval.Status.Conditions, metav1.Condition{
@@ -437,7 +444,7 @@ func (r *FraudEvaluationReconciler) setErrorPhase(ctx context.Context, eval *fra
 		ObservedGeneration: eval.Generation,
 	})
 
-	if err := r.Status().Update(ctx, eval); err != nil {
+	if err := r.Status().Patch(ctx, eval, client.MergeFrom(base)); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to set Error phase: %w", err)
 	}
 
@@ -542,6 +549,15 @@ func (r *FraudEvaluationReconciler) applyEnforcement(ctx context.Context, eval *
 		log.Info("PlatformAccessApproval ensured", "name", resourceName, "user", eval.Spec.UserRef.Name)
 
 	default:
+		// Empty decision means we were called before status.decision was set
+		// (e.g. a stale read between Status().Update and the cache catching up).
+		// Returning a non-terminal condition would lock the eval forever via the
+		// EnforcementApplied=True short-circuit at the top of this function. Just
+		// requeue and let the next reconcile observe the real decision.
+		if eval.Status.Decision == "" {
+			log.Info("decision not yet observed, requeueing for next reconcile", "eval", eval.Name)
+			return ctrl.Result{Requeue: true}, nil
+		}
 		// Unknown or legacy decision value — log and skip enforcement rather than error-looping.
 		log.Info("skipping enforcement for unrecognised decision", "decision", eval.Status.Decision)
 		return r.setEnforcementAppliedCondition(ctx, eval, "SkippedUnknownDecision", fmt.Sprintf("Enforcement skipped: unrecognised decision %q", eval.Status.Decision))

--- a/internal/controller/fraudevaluation_controller_test.go
+++ b/internal/controller/fraudevaluation_controller_test.go
@@ -783,6 +783,65 @@ var _ = Describe("FraudEvaluation Controller", func() {
 			Expect(cond.Message).To(ContainSubstring("prior-eval-rejection"))
 		})
 
+		// Regression: in prod we observed evaluations stuck with status.decision=ACCEPTED
+		// but EnforcementApplied=True with reason="SkippedUnknownDecision" and
+		// message=`unrecognised decision ""`. Same reconcileID logged "evaluation
+		// completed decision: ACCEPTED" then immediately "skipping enforcement for
+		// unrecognised decision decision: ''". Root cause: Reconcile re-fetches the
+		// eval via the cached client after Status().Update, the cache hasn't seen
+		// the update yet, the stale read has decision="", applyEnforcement's default
+		// branch sets EnforcementApplied=True permanently, and the short-circuit at
+		// the top of applyEnforcement blocks any future retry.
+		//
+		// This test exercises the same observable state by calling applyEnforcement
+		// directly with an eval whose status.decision is empty. With the fix
+		// (default branch returns without setting the condition when decision==""),
+		// no PAA is created and no terminal condition is set, so the next reconcile
+		// can recover. Without the fix, the eval is permanently locked.
+		It("should not permanently lock an eval when applyEnforcement is called with an empty decision (cache-lag race regression)", func() {
+			createResources(15, "FailOpen", "AUTO")
+
+			eval := &fraudv1alpha1.FraudEvaluation{
+				ObjectMeta: metav1.ObjectMeta{Name: "eval-empty-decision"},
+				Spec: fraudv1alpha1.FraudEvaluationSpec{
+					UserRef:   fraudv1alpha1.UserReference{Name: "user-empty-decision"},
+					PolicyRef: fraudv1alpha1.PolicyReference{Name: policyName},
+				},
+			}
+			Expect(k8sClient.Create(ctx, eval)).To(Succeed())
+
+			// Storage state: pipeline already ran, decision is ACCEPTED, phase is
+			// Completed. This is what the API server would have after the
+			// Status().Update at fraudevaluation_controller.go:187.
+			eval.Status.Phase = fraudv1alpha1.PhaseCompleted
+			eval.Status.Decision = fraudv1alpha1.DecisionAccepted
+			eval.Status.EnforcementAction = "ENFORCED"
+			Expect(k8sClient.Status().Update(ctx, eval)).To(Succeed())
+
+			var policy fraudv1alpha1.FraudPolicy
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: policyName}, &policy)).To(Succeed())
+
+			// Stale snapshot: this is what r.Get returns from the cache before
+			// the watch event for the Update above has been delivered. Same name
+			// (so the patch in setEnforcementAppliedCondition targets the live
+			// object) but decision="".
+			stale := eval.DeepCopy()
+			stale.Status.Decision = ""
+
+			_, err := reconciler.applyEnforcement(ctx, stale, &policy)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Re-fetch the live object: it should NOT have been permanently
+			// marked EnforcementApplied=SkippedUnknownDecision based on the
+			// stale empty decision.
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "eval-empty-decision"}, eval)).To(Succeed())
+			cond := meta.FindStatusCondition(eval.Status.Conditions, conditionEnforcementApplied)
+			if cond != nil {
+				Expect(cond.Reason).NotTo(Equal("SkippedUnknownDecision"),
+					"applyEnforcement must not lock the eval with SkippedUnknownDecision when decision is empty — that prevents the next reconcile (which sees the real ACCEPTED decision) from creating the PAA")
+			}
+		})
+
 		It("should set Error phase when provider is not registered", func() {
 			// Create resources but do NOT register anything in the registry.
 			fp := &fraudv1alpha1.FraudProvider{


### PR DESCRIPTION
## Summary

Fixes a long-standing race that causes ACCEPTED FraudEvaluations to be permanently locked without a corresponding `PlatformAccessApproval`, blocking affected users from logging in. Currently 5 such users in prod (verified 2026-04-29).

## The bug

`Reconcile()` re-reads the FraudEvaluation from the controller-runtime cache immediately after `Status().Update()`:

```go
// 11. Re-fetch to get the latest resourceVersion before patching status again.
if err := r.Get(ctx, req.NamespacedName, &eval); err != nil { ... }

// 12. Apply enforcement based on policy mode and decision.
return r.applyEnforcement(ctx, &eval, &policy)
```

The default Client serves Get from the cached informer. The watch event for the Update we just performed has not necessarily been delivered to the cache yet, so `r.Get` can (and in prod did) return the eval as it was BEFORE the Update — including an empty `status.decision`.

That empty decision then flows into `applyEnforcement`, hits the default switch branch, and permanently sets `EnforcementApplied=True` with reason `SkippedUnknownDecision`. The short-circuit at the top of `applyEnforcement`:

```go
if meta.IsStatusConditionTrue(eval.Status.Conditions, conditionEnforcementApplied) {
    return ctrl.Result{}, nil
}
```

then blocks every future reconcile of this eval — even after the cache catches up and shows `decision=ACCEPTED`. The PAA is never created. The user is stuck.

## Smoking gun from prod

Same `reconcileID`, same second, two log lines:

```
13:00:11Z INFO  evaluation completed       reconcileID: 13cbab90-...  decision: ACCEPTED
13:00:11Z INFO  skipping enforcement for   reconcileID: 13cbab90-...  decision: ""
                unrecognised decision
```

The only operation between those two log statements is the cached re-Get. Decision can't go from ACCEPTED to `""` any other way.

## Fix

### 1. Drop the unnecessary re-Get (root cause)

`Status().Update()` / `Status().Patch()` already populate the in-memory `eval.ResourceVersion` in place, so the subsequent patch in `setEnforcementAppliedCondition` targets the correct revision without a re-fetch. Use the in-memory eval directly.

### 2. Convert `Status().Update()` → `Status().Patch(client.MergeFrom(base))`

For consistency with `setEnforcementAppliedCondition` (which already uses Patch) and for safer concurrent-write semantics (only sends the diff, doesn't overwrite fields we didn't touch).

**Caught a latent bug while doing this**: `eval.Status.History` was being mutated BEFORE the `base := eval.DeepCopy()` snapshot was captured, which would have silently dropped the History field from the patch diff once we switched to Patch. Fixed by hoisting the snapshot above all status mutations. This isn't observable today (Update sends the full object) but would have surfaced as a regression the moment we made the Update→Patch change without reordering.

### 3. Belt-and-suspenders: requeue on empty decision

In `applyEnforcement`'s default branch, requeue without setting a terminal condition when `decision == ""`. Correctly distinguishes:
- `decision == ""` → transient bug state (race, missed write, whatever) → requeue and let next reconcile observe the real value
- `decision == "<unrecognised>"` → real unknown/legacy value → keep `SkippedUnknownDecision` (needs human intervention)

Without #1, this alone would also have prevented the lock. With #1, this is defense-in-depth against any future code that re-introduces a similar race.

## How long has this been happening?

The re-Get was added 2026-03-17 (commit `188c6ea`). The `SkippedUnknownDecision` default branch was added 2026-03-19. The race has been latent for ~6 weeks. It's probabilistic — most reconciles win the race and create the PAA correctly. In prod we currently see 5 stuck out of ~290 ACCEPTED users (~1.7% loss rate). This isn't a regression introduced in any specific recent release — `v0.2.1`, `v0.2.2`, and `v0.2.3` all exhibit it.

## Test plan

- [x] New regression test: `should not permanently lock an eval when applyEnforcement is called with an empty decision (cache-lag race regression)` — calls `applyEnforcement` directly with empty decision, asserts the eval is NOT marked `EnforcementApplied=SkippedUnknownDecision`. Fails on the pre-fix code, passes after.
- [x] Full controller suite: 26/26 specs pass.
- [x] `go build ./...` and `go vet ./...` clean.
- [ ] After merge & deploy: confirm no new ACCEPTED evals end up with `EnforcementApplied=SkippedUnknownDecision`.
- [ ] After deploy: manually unstick the 5 currently stuck evals (delete the bad `EnforcementApplied` condition; controller will re-run with the correct ACCEPTED decision and create the PAA).

## Out of scope

- The 3 ACCEPTED users in prod blocked by admin-created PARs (`platform-access-rejection-nr5rd` reason "Looks like spam account", etc.) — this PR doesn't change that; they remain blocked by the IAM webhook. PR #25 already prevents the controller from error-looping on them. Admins should clean up the PARs if those users should actually be approved.
