### PR TITLE
feat: alert on FraudEvaluation DEACTIVATE or REVIEW decisions

### DIFF
--- a/config/prometheus/vmrule.yaml
+++ b/config/prometheus/vmrule.yaml
@@ -83,3 +83,14 @@ spec:
           annotations:
             summary: "Fraud evaluation {{ $labels.name }} is degraded"
             description: "Fraud evaluation {{ $labels.name }} has been in a degraded state for 5+ minutes, indicating one or more providers returned errors during evaluation."
+
+        - alert: FraudEvaluationUserDeactivatedOrReview
+          expr: |
+            max by (name, user_ref, decision) (fraud_evaluation_info{decision=~"DEACTIVATE|REVIEW"}) == 1
+          for: 0m
+          labels:
+            severity: warning
+            slack_channel: user-bot
+          annotations:
+            summary: "Fraud check returned {{ $labels.decision }} for user {{ $labels.user_ref }}"
+            description: "FraudEvaluation {{ $labels.name }} returned decision={{ $labels.decision }} for user {{ $labels.user_ref }}. Review the user and take action if needed."


### PR DESCRIPTION
## Summary

- Adds a new `FraudEvaluationUserDeactivatedOrReview` rule to `config/prometheus/vmrule.yaml`.
- Fires when a `FraudEvaluation` lands on `decision=DEACTIVATE` or `decision=REVIEW`.
- Carries `slack_channel: user-bot` so the cluster Alertmanager (see datum-cloud/infra#2300) routes it into the user-bot Slack channel rather than the infra severity channels.

## Why

Today these fraud outcomes only surface in the FraudEvaluation status; there is no proactive notification. Alerting via VMRule + Alertmanager keeps the routing out of bespoke webhooks and reuses the existing observability path.

## Mechanism

- Backed by `fraud_evaluation_info{decision="..."}` from the `ResourceMetricsPolicy` in `config/resourcemetrics/fraud-evaluation-metrics-policy.yaml`.
- `max by (name, user_ref, decision)` collapses replicas of the same series so a single deactivation fires once per (name, user_ref, decision).
- `for: 0m` so the alert fires immediately when the decision flips — these are user-impacting events, not transient health blips.

## Dependencies

- Requires datum-cloud/infra PR adding the `slack-user-bot` Alertmanager route to land first; until then alerts route to `slack-warning` (default) which is harmless.
- Production also requires datum-cloud/infra PR removing the `../resourcemetrics` strip-patch so `fraud_evaluation_info` is emitted in prod.

## Test plan

- [ ] `kustomize build config/prometheus/` succeeds (verified locally).
- [ ] In staging, force a `DEACTIVATE` or `REVIEW` decision on a test FraudEvaluation and confirm the alert fires.
- [ ] Confirm alert lands in the user-bot Slack channel after Alertmanager PR merges.
- [ ] Confirm existing alerts in this VMRule still fire correctly (regression check).