### PR TITLE
fix: rename metrics RBAC to be operator-scoped

### DIFF
--- a/config/rbac/metrics_auth_role.yaml
+++ b/config/rbac/metrics_auth_role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: metrics-auth-role
+  name: fraud-metrics-auth-role
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/config/rbac/metrics_auth_role_binding.yaml
+++ b/config/rbac/metrics_auth_role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: metrics-auth-rolebinding
+  name: fraud-metrics-auth-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: metrics-auth-role
+  name: fraud-metrics-auth-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/config/rbac/metrics_reader_role.yaml
+++ b/config/rbac/metrics_reader_role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: metrics-reader
+  name: fraud-metrics-reader
 rules:
 - nonResourceURLs:
   - "/metrics"


### PR DESCRIPTION
## Problem

The `config/rbac/` path deploys three cluster-scoped RBAC resources using kubebuilder's default generic names:
- `ClusterRole/metrics-reader`
- `ClusterRole/metrics-auth-role`
- `ClusterRoleBinding/metrics-auth-rolebinding`

FluxCD deploys these via the `fraud-rbac` Kustomization using `path: rbac`, which does not apply any `namePrefix`. This causes ownership conflicts with identically-named resources deployed by other operators (e.g., `compute-manager`, `dns-operator-rbac`), triggering FluxCD alerts in staging.

## Fix

Rename the three resources to be operator-scoped:
- `metrics-reader` → `fraud-metrics-reader`
- `metrics-auth-role` → `fraud-metrics-auth-role`
- `metrics-auth-rolebinding` → `fraud-metrics-auth-rolebinding`

The `roleRef` in the ClusterRoleBinding is updated to reference the new `fraud-metrics-auth-role` name.

Note: the `config/default/` path also includes these resources via `../rbac`, but with `namePrefix: fraud-` applied — so those resources were already landing with `fraud-` prefixed names. The `config/rbac/` path (used by FluxCD in production) had no prefix applied, which was the source of the conflict.

Fixes #35