### PR TITLE
Update references for the move to milo-os

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,8 +25,8 @@ jobs:
       packages: write
     uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.9.0
     with:
-      bundle-name: ghcr.io/datum-cloud/fraud-kustomize
+      bundle-name: ghcr.io/milo-os/fraud-kustomize
       bundle-path: config
       image-overlays: config/manager
-      image-name: ghcr.io/datum-cloud/fraud
+      image-name: ghcr.io/milo-os/fraud
     secrets: inherit

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,6 +14,7 @@ jobs:
       attestations: write
     uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.9.0
     with:
+      registry-organization: milo-os
       image-name: fraud
     secrets: inherit
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/datum-cloud/fraud:latest
+IMG ?= ghcr.io/milo-os/fraud:latest
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -198,7 +198,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 # MILO_REF pins the milo branch/tag/SHA used to fetch IAM CRDs for e2e tests.
 MILO_REF ?= main
-MILO_IAM_CRDS_URL ?= https://github.com/datum-cloud/milo//config/crd/bases/iam?ref=$(MILO_REF)
+MILO_IAM_CRDS_URL ?= https://github.com/milo-os/milo//config/crd/bases/iam?ref=$(MILO_REF)
 
 .PHONY: install-milo-crds
 install-milo-crds: ## Install milo IAM CRDs (PlatformAccessApproval, PlatformAccessRejection, etc.) needed by the controller cache informers in e2e.

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,5 +7,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: ghcr.io/datum-cloud/fraud
+  newName: ghcr.io/milo-os/fraud
   newTag: latest

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -15,7 +15,7 @@ import (
 var (
 	// projectImage is the name of the image which will be build and loaded
 	// with the code source changes to be tested.
-	projectImage = "ghcr.io/datum-cloud/fraud:e2e"
+	projectImage = "ghcr.io/milo-os/fraud:e2e"
 )
 
 // TestE2E runs the end-to-end (e2e) test suite for the project.


### PR DESCRIPTION
This repo recently moved from [datum-cloud](https://github.com/datum-cloud) to [milo-os](https://github.com/milo-os). Updates internal links and image references to reflect the new home.