### PR TITLE
Observe mode no longer blocks users

### DIFF
--- a/internal/controller/fraudevaluation_controller.go
+++ b/internal/controller/fraudevaluation_controller.go
@@ -477,9 +477,9 @@ func (r *FraudEvaluationReconciler) applyEnforcement(ctx context.Context, eval *
 				ObjectMeta: metav1.ObjectMeta{
 					Name: resourceName,
 					Annotations: map[string]string{
-						"fraud.miloapis.com/observe-mode":       "true",
-						"fraud.miloapis.com/observed-decision":  eval.Status.Decision,
-						"fraud.miloapis.com/observed-score":     eval.Status.CompositeScore,
+						"fraud.miloapis.com/observe-mode":      "true",
+						"fraud.miloapis.com/observed-decision": eval.Status.Decision,
+						"fraud.miloapis.com/observed-score":    eval.Status.CompositeScore,
 					},
 				},
 				Spec: iamv1alpha1.PlatformAccessApprovalSpec{

--- a/internal/controller/fraudevaluation_controller.go
+++ b/internal/controller/fraudevaluation_controller.go
@@ -462,10 +462,40 @@ func (r *FraudEvaluationReconciler) applyEnforcement(ctx context.Context, eval *
 		return ctrl.Result{}, nil
 	}
 
-	// OBSERVE mode: log but do not create enforcement resources.
+	// OBSERVE mode: always approve the user so they are not blocked, but record
+	// what the real decision would have been. No deactivation is ever created.
 	if policy.Spec.Enforcement.Mode == fraudv1alpha1.EnforcementModeObserve {
-		log.Info("enforcement skipped (OBSERVE mode)", "decision", eval.Status.Decision)
-		return r.setEnforcementAppliedCondition(ctx, eval, "ObserveMode", "Enforcement skipped: policy is in OBSERVE mode")
+		log.Info("OBSERVE mode: approving user regardless of decision", "decision", eval.Status.Decision, "user", eval.Spec.UserRef.Name)
+
+		var paas iamv1alpha1.PlatformAccessApprovalList
+		if err := r.List(ctx, &paas, client.MatchingFields{"spec.subjectRef.userRef.name": eval.Spec.UserRef.Name}); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to list PlatformAccessApprovals for user %q: %w", eval.Spec.UserRef.Name, err)
+		}
+		if len(paas.Items) == 0 {
+			resourceName := enforcementResourcePrefix + eval.Name
+			approval := &iamv1alpha1.PlatformAccessApproval{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: resourceName,
+					Annotations: map[string]string{
+						"fraud.miloapis.com/observe-mode":       "true",
+						"fraud.miloapis.com/observed-decision":  eval.Status.Decision,
+						"fraud.miloapis.com/observed-score":     eval.Status.CompositeScore,
+					},
+				},
+				Spec: iamv1alpha1.PlatformAccessApprovalSpec{
+					SubjectRef: iamv1alpha1.SubjectReference{
+						UserRef: &iamv1alpha1.UserReference{Name: eval.Spec.UserRef.Name},
+					},
+				},
+			}
+			if err := r.Create(ctx, approval); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to create observer PlatformAccessApproval %q: %w", resourceName, err)
+			}
+			log.Info("observer PlatformAccessApproval created", "name", resourceName, "user", eval.Spec.UserRef.Name)
+		}
+
+		return r.setEnforcementAppliedCondition(ctx, eval, "ObserveMode",
+			fmt.Sprintf("User approved (OBSERVE mode); observed decision was %s (score: %s)", eval.Status.Decision, eval.Status.CompositeScore))
 	}
 
 	resourceName := enforcementResourcePrefix + eval.Name

--- a/internal/controller/fraudevaluation_controller_test.go
+++ b/internal/controller/fraudevaluation_controller_test.go
@@ -611,7 +611,7 @@ var _ = Describe("FraudEvaluation Controller", func() {
 			Expect(approval.Spec.SubjectRef.UserRef.Name).To(Equal("user-accepted"))
 		})
 
-		It("OBSERVE mode should not create any IAM resources", func() {
+		It("OBSERVE mode should approve the user and not create any deactivation resources", func() {
 			createResources(95, "FailOpen", "OBSERVE")
 
 			eval := &fraudv1alpha1.FraudEvaluation{
@@ -628,12 +628,18 @@ var _ = Describe("FraudEvaluation Controller", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			// No UserDeactivation should be created.
+			// No UserDeactivation should be created even for a high-score user.
 			deactivation := &iamv1alpha1.UserDeactivation{}
 			err = k8sClient.Get(ctx, types.NamespacedName{Name: "fraud-eval-observe-noiam"}, deactivation)
 			Expect(err).To(HaveOccurred())
 
-			// EnforcementApplied condition should still be set with ObserveMode reason.
+			// A PlatformAccessApproval should be created so the user is not blocked.
+			approval := &iamv1alpha1.PlatformAccessApproval{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "fraud-eval-observe-noiam"}, approval)).To(Succeed())
+			Expect(approval.Annotations).To(HaveKeyWithValue("fraud.miloapis.com/observe-mode", "true"))
+			Expect(approval.Annotations).To(HaveKeyWithValue("fraud.miloapis.com/observed-decision", fraudv1alpha1.DecisionDeactivate))
+
+			// EnforcementApplied condition should be set with ObserveMode reason.
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "eval-observe-noiam"}, eval)).To(Succeed())
 			cond := meta.FindStatusCondition(eval.Status.Conditions, conditionEnforcementApplied)
 			Expect(cond).NotTo(BeNil())


### PR DESCRIPTION
## What changed

When a fraud policy is set to **Observe** mode, users were getting stuck waiting for access approval — indefinitely, with no explanation. This happened because Observe mode was skipping *all* enforcement actions, including the approval step.

Observe mode is meant to be a safe, non-disruptive way to test a policy before turning it on for real. Users should never be blocked by it.

## What it does now

Users are automatically approved while the policy is in Observe mode. Their fraud score and what the decision *would* have been are recorded on the approval for visibility, but nothing is enforced.

## What hasn't changed

- Users are still evaluated through the full fraud pipeline
- The score and would-be decision are still recorded on the `FraudEvaluation`
- Deactivations are still never triggered in Observe mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)